### PR TITLE
change dsp error message, add (unfinished) ufo and ship trails + minor cube particles adjustments

### DIFF
--- a/source/graphics.c
+++ b/source/graphics.c
@@ -1013,6 +1013,8 @@ void draw_objects() {
             draw_object_particles();
             for (int i = 0; i < 2; i++) {
                 drawParticleSystem(&drag_particles[i], 0, 0, 1.f);
+                drawParticleSystem(&ship_fire_particles[i], 0, 0, 1.f);
+                drawParticleSystem(&ufo_secondary_particles[i], 0, 0, 1.f);
                 drawParticleSystem(&burst_particles[i], 0, 0, 1.f);
             }
             change_blending(false);

--- a/source/main.c
+++ b/source/main.c
@@ -173,6 +173,12 @@ void game_loop() {
 
     initParticleSystem(&drag_particles_2[0], &ship_drag_effect);
     initParticleSystem(&drag_particles_2[1], &ship_drag_effect);
+
+    initParticleSystem(&ship_fire_particles[0], &drag_effect);
+    initParticleSystem(&ship_fire_particles[1], &drag_effect);
+
+    initParticleSystem(&ufo_secondary_particles[0], &drag_effect);
+    initParticleSystem(&ufo_secondary_particles[1], &drag_effect);
     
     initParticleSystem(&burst_particles[0], &burst_effect);
     initParticleSystem(&burst_particles[1], &burst_effect);
@@ -187,6 +193,22 @@ void game_loop() {
     burst_particles[0].cfg.startColorRed   = p1_not_white.r / 255.f;
     burst_particles[0].cfg.startColorGreen = p1_not_white.g / 255.f;
     burst_particles[0].cfg.startColorBlue  = p1_not_white.b / 255.f;
+
+    ufo_secondary_particles[0].cfg.startColorRed   = p2_not_white.r / 255.f;
+    ufo_secondary_particles[0].cfg.startColorGreen = p2_not_white.g / 255.f;
+    ufo_secondary_particles[0].cfg.startColorBlue  = p2_not_white.b / 255.f;
+
+    ufo_secondary_particles[1].cfg.startColorRed   = p1_not_white.r / 255.f;
+    ufo_secondary_particles[1].cfg.startColorGreen = p1_not_white.g / 255.f;
+    ufo_secondary_particles[1].cfg.startColorBlue  = p1_not_white.b / 255.f;
+
+    // ship_fire_particles[0].cfg.startColorRed   = 255.f;
+    // ship_fire_particles[0].cfg.startColorGreen = 65.f;
+    // ship_fire_particles[0].cfg.startColorBlue  = 0.f;
+
+    // ship_fire_particles[1].cfg.startColorRed   = 255.f;
+    // ship_fire_particles[1].cfg.startColorGreen = 65.f;
+    // ship_fire_particles[1].cfg.startColorBlue  = 0.f;
 
     drag_particles[1].cfg.startColorRed   = p2_not_white.r / 255.f;
     drag_particles[1].cfg.startColorGreen = p2_not_white.g / 255.f;
@@ -253,6 +275,8 @@ void game_loop() {
                 drag_particles[i].emitting = false;
                 drag_particles_2[i].stationary = true;
                 drag_particles_2[i].emitting = false;
+                ship_fire_particles[i].emitting = false;
+                ufo_secondary_particles[i].emitting = false;
                 burst_particles[i].emitting = false;
             }
             
@@ -350,6 +374,8 @@ void game_loop() {
             for (int i = 0; i < 2; i++) {
                 updateParticleSystem(&drag_particles[i], delta);
                 updateParticleSystem(&drag_particles_2[i], delta);
+                updateParticleSystem(&ship_fire_particles[i], delta);
+                updateParticleSystem(&ufo_secondary_particles[i], delta);
                 updateParticleSystem(&burst_particles[i], delta);
             }
             update_object_particles();
@@ -458,12 +484,15 @@ void game_loop() {
 
     freeParticleData(&drag_particles[0].data);
     freeParticleData(&drag_particles_2[0].data);
+freeParticleData(&ship_fire_particles[0].data);
+    freeParticleData(&ufo_secondary_particles[0].data);
     freeParticleData(&burst_particles[0].data);
-    
-    freeParticleData(&drag_particles[1].data);
-    freeParticleData(&drag_particles[1].data);
-    freeParticleData(&burst_particles[1].data);
 
+    freeParticleData(&drag_particles[1].data);
+    freeParticleData(&drag_particles[1].data);
+    freeParticleData(&ship_fire_particles[1].data);
+    freeParticleData(&ufo_secondary_particles[1].data);
+    freeParticleData(&burst_particles[1].data);
     unload_level();
 
     game_state = STATE_LEVEL_SELECT;

--- a/source/main.c
+++ b/source/main.c
@@ -56,11 +56,11 @@ bool is_citra() {
 
 void no_dsp_firmware(void) {
     consoleInit(GFX_TOP, NULL);
-    printf("\x1b[01;00H/////////////FATAL///ERROR////////////////////////");
+    printf("\x1b[01;00H/////////////////FATAL///ERROR////////////////////");
     printf("\x1b[03;00HNDSP could not be initalized.");
     printf("\x1b[05;00HThis is probably because your dspfirm is missing.");
-    printf("\x1b[07;00HPut the ndsp firmwared called dspfirm.cdc");
-    printf("\x1b[09;00Hon your sd card in sdmc:/3ds");
+    printf("\x1b[07;00HExtract the ndsp firmware (nsdp.cdc) to sdmc:/3ds/");
+    printf("\x1b[09;00Hon your sd card.");
     printf("\x1b[11;00HCitra/Azahar users only need the file to be there,");
     printf("\x1b[13;00Hit can be empty.");
     printf("\x1b[15;00HPress start to exit.");

--- a/source/main.c
+++ b/source/main.c
@@ -59,8 +59,8 @@ void no_dsp_firmware(void) {
     printf("\x1b[01;00H/////////////////FATAL///ERROR////////////////////");
     printf("\x1b[03;00HNDSP could not be initalized.");
     printf("\x1b[05;00HThis is probably because your dspfirm is missing.");
-    printf("\x1b[07;00HExtract the ndsp firmware (nsdp.cdc) to sdmc:/3ds/");
-    printf("\x1b[09;00Hon your sd card.");
+    printf("\x1b[07;00HExtract the ndsp firmware (dspfirm.cdc) to");
+    printf("\x1b[09;00Hsdmc:/3ds/ on your sd card.");
     printf("\x1b[11;00HCitra/Azahar users only need the file to be there,");
     printf("\x1b[13;00Hit can be empty.");
     printf("\x1b[15;00HPress start to exit.");

--- a/source/player/player.c
+++ b/source/player/player.c
@@ -25,6 +25,8 @@ MotionTrail wave_trail_p2;
 
 ParticleSystem drag_particles[2];
 ParticleSystem drag_particles_2[2];
+ParticleSystem ship_fire_particles[2];
+ParticleSystem ufo_secondary_particles[2];
 ParticleSystem burst_particles[2];
 
 
@@ -89,9 +91,9 @@ void cube_gamemode(Player *player) {
         player->rotation += 415.3848f * STEPS_DT * mult * (player->mini ? 1.2f : 1.f);
     }
 
-    drag_particles[state.current_player].emitterX = getLeft(player) - 2;
+    drag_particles[state.current_player].emitterX = getLeft(player);
     drag_particles[state.current_player].emitterY = fabsf(gravBottom(player)) + (player->upside_down ? -4 : 4);
-    drag_particles[state.current_player].emitting = player->time_since_ground < 0.05f;
+    drag_particles[state.current_player].emitting = player->time_since_ground < 0.1f;
 
     drag_particles[state.current_player].gravityFlipped = player->upside_down;
     drag_particles[state.current_player].scale = (player->mini ? 0.6f : 1.0f);
@@ -177,6 +179,14 @@ void ship_gamemode(Player *player) {
     float calc_x = player->x - state.camera_x;
     float calc_y = SCREEN_HEIGHT - (fabsf(gravBottom(player)) - state.camera_y);
 
+    ship_fire_particles[state.current_player].emitterX = getLeft(player) + 2;
+    ship_fire_particles[state.current_player].emitterY = fabsf(gravBottom(player)) + (player->upside_down ? -6 : 6);
+    ship_fire_particles[state.current_player].emitting = false;
+
+    // ship_fire_particles[state.current_player].gravityFlipped = true;
+    ship_fire_particles[state.current_player].scale = (player->mini ? 0.6f : 1.0f);
+
+
     drag_particles_2[state.current_player].emitterX = calc_x;
     drag_particles_2[state.current_player].emitterY = calc_y;
     drag_particles_2[state.current_player].emitting = player->on_ground;
@@ -201,6 +211,7 @@ void ship_gamemode(Player *player) {
     } else {
         if (state.input.holdJump) {
             player->buffering_state = BUFFER_END;
+            ship_fire_particles[state.current_player].emitting = true;
             if (player->vel_y <= grav(player, 101.541492f))
                 player->gravity = player->mini ? 1643.5872f : 1397.0491f;
             else
@@ -305,6 +316,13 @@ void ufo_gamemode(Player *player) {
 
     trail->positionR = (Vec2){x, y};  
     trail->startingPositionInitialized = true;
+
+    ufo_secondary_particles[state.current_player].emitterX = player->x;
+    ufo_secondary_particles[state.current_player].emitterY = fabsf(gravBottom(player)) + (player->upside_down ? -3 : 3);
+    ufo_secondary_particles[state.current_player].emitting = true;
+
+    ufo_secondary_particles[state.current_player].gravityFlipped = player->upside_down;
+    ufo_secondary_particles[state.current_player].scale = (player->mini ? 0.6f : 1.0f);
 
     drag_particles_2[state.current_player].emitterX = calc_x;
     drag_particles_2[state.current_player].emitterY = calc_y;

--- a/source/player/player.h
+++ b/source/player/player.h
@@ -149,6 +149,8 @@ extern MotionTrail wave_trail_p2;
 
 extern ParticleSystem drag_particles[2];
 extern ParticleSystem drag_particles_2[2];
+extern ParticleSystem ship_fire_particles[2];
+extern ParticleSystem ufo_secondary_particles[2];
 extern ParticleSystem burst_particles[2];
 
 extern const float player_speeds[SPEED_COUNT];


### PR DESCRIPTION
ufo and ship particles dont rotate along with the player, ship particles lack colour and the ufo particles are the wrong type. i changed the cube particles to have the same delay as in 1.9 and also adjusted their spawn location to be closer to actual gd 