### PR TITLE
Fix the pause thingy

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -465,8 +465,11 @@ void game_loop() {
         }
     }
 
-    if (song_loaded) pause_playback_mp3();
-
+    if (song_loaded) {
+		pause_playback_mp3();
+		bool playing_menu_loop = false;
+	}
+	
     set_fade_status(FADE_STATUS_IN);
 
     bool being_faded = true;

--- a/source/state.c
+++ b/source/state.c
@@ -342,7 +342,7 @@ void init_variables() {
 
 void handle_death(Player *player) {
     play_sfx(&explode_sound, 1);
-    if (song_loaded) {
+    if (song_loaded && !playing_menu_loop) {
         pause_playback_mp3();
         seek_mp3(level_info.song_offset);
     }


### PR DESCRIPTION
Issue: killing an icon on the main menu pauses the menu music
Fix: inject a check if main menu music is playing into the handle_death check for pausing the mp3, set main menu music playing to false when starting a level