### PR TITLE
Various button/level select fixes

### DIFF
--- a/source/menus/components/ui_button.c
+++ b/source/menus/components/ui_button.c
@@ -20,10 +20,9 @@ static void ui_button_update(UIElement* e, UIInput* touch) {
     //Keybinds logic
     u32 validKeybinds = e->button.keyBinds;
 
-    if(enableDebugBindings){
-        validKeybinds &= ~(KEY_X | KEY_L | KEY_R);
+    if(enableDebugBindings && game_state == STATE_GAME){
+        validKeybinds &= ~(KEY_B | KEY_X | KEY_L | KEY_R);
     }
-    //validKeybinds &= ~hidKeysDownRepeat();
 
     if((hidKeysDown() & validKeybinds) > 0){
         e->button.pressed = true;

--- a/source/menus/components/ui_button.c
+++ b/source/menus/components/ui_button.c
@@ -10,6 +10,7 @@
 #include "math_helpers.h"
 #include "ui_screen.h"
 #include "menus/settings.h"
+#include "menus/gameplay.h"
 
 #include "main.h"
 
@@ -20,7 +21,7 @@ static void ui_button_update(UIElement* e, UIInput* touch) {
     //Keybinds logic
     u32 validKeybinds = e->button.keyBinds;
 
-    if(enableDebugBindings && game_state == STATE_GAME){
+    if(enableDebugBindings && game_state == STATE_GAME && !game_paused){
         validKeybinds &= ~(KEY_B | KEY_X | KEY_L | KEY_R);
     }
 

--- a/source/menus/icon_kit.c
+++ b/source/menus/icon_kit.c
@@ -78,6 +78,8 @@ static int *current_pages[GAMEMODE_COUNT + 1] = {
     &current_trail_page
 };
 
+static UIElement *gamemode_btns[GAMEMODE_COUNT + 1];
+
 int *current_icons[GAMEMODE_COUNT + 1] = {
     &selected_cube,
     &selected_ship,
@@ -271,6 +273,13 @@ void icon_kit_loop() {
         playing_menu_loop = true;
     }
 
+    gamemode_btns[0] = ui_get_element_by_tag(&screen, "cube");
+    gamemode_btns[1] = ui_get_element_by_tag(&screen, "ship");
+    gamemode_btns[2] = ui_get_element_by_tag(&screen, "ball");
+    gamemode_btns[3] = ui_get_element_by_tag(&screen, "ufo");
+    gamemode_btns[4] = ui_get_element_by_tag(&screen, "dart");
+    gamemode_btns[5] = ui_get_element_by_tag(&screen, "trail");
+
     while (aptMainLoop()) {
         hidScanInput();
 
@@ -280,6 +289,15 @@ void icon_kit_loop() {
         touch.touchPosition = touchPos;
         touch.did_something = false;
         touch.interacted = false;
+
+        for(int i = 0; i < GAMEMODE_COUNT + 1; i++){
+            gamemode_btns[i]->button.keyBinds = 0;
+            if(i == gamemode_page - 1){
+                gamemode_btns[i]->button.keyBinds |= KEY_L | KEY_ZL;
+            } else if(i == gamemode_page + 1){
+                gamemode_btns[i]->button.keyBinds |= KEY_R | KEY_ZR;
+            } 
+        }
 
         if (!in_palette_kit) ui_screen_update(&screen, &touch);
         ui_screen_update(&screen_top, &touch);

--- a/source/menus/level_select.c
+++ b/source/menus/level_select.c
@@ -35,8 +35,6 @@ int curr_level_id = 0;
 
 s8 scroll_dir = 0;
 
-float scrolled = 0;
-
 float anim_time = 0;
 
 static bool dragging;
@@ -248,6 +246,7 @@ void recenter(){
     update_level_name(curr_level_id, 0);
     update_level_stars(curr_level_id, 0);
     update_level_progress(curr_level_id, 0);
+    ui_run_func_on_tag(&screen, "level_card_2", disable_card_2);
 }
 
 void handle_card_movement() {
@@ -270,6 +269,7 @@ void handle_card_movement() {
         float end = (scroll_dir == 0) ? 0 : 320;
 
         float fade_value = easeValue(ELASTIC_OUT, start, end, anim_time, ANIM_DURATION, 0.6f);
+
         float value = (scroll_dir == 0) ? 160 + fade_value : 160 + fade_value * scroll_dir;
         anim_time += 0.016666f;
 
@@ -281,7 +281,6 @@ void handle_card_movement() {
 void action_move_right(UIElement* e) { 
     curr_level_id++;
     scroll_dir = -1;
-    scrolled = 0;
     anim_time = 0;
     
     if (curr_level_id >= MAIN_LEVELS_NUM) curr_level_id = 0;
@@ -307,7 +306,6 @@ void action_move_right(UIElement* e) {
 void action_move_left(UIElement* e) { 
     curr_level_id--;
     scroll_dir = 1;
-    scrolled = 0;
     anim_time = 0;
 
     if (curr_level_id < 0) curr_level_id = MAIN_LEVELS_NUM-1;
@@ -447,6 +445,7 @@ void level_select_loop() {
     ui_run_func_on_tag(&screen, "level_card_2", disable_card_2);
 
     u32 color = default_lvl_colors[curr_level_id % NUM_MENU_COLORS];
+    upload_color_to_buffer(0, color, 0);
 
     channels[0].color.r = GET_R(color);
     channels[0].color.g = GET_G(color);
@@ -494,18 +493,20 @@ void level_select_loop() {
             dragStartX = touch.touchPosition.px;
             dragDistance = 0;
             dragDir = 0;
+            dragging = false;
+            scroll_dir = 0;
             recenter();
         }
         if((kHeld & KEY_TOUCH)){
             if(dragging){
                 int delta = touch.touchPosition.px - lastTouchX;
-                lastTouchX = touch.touchPosition.px;
                 dragDistance += delta;
 
-                if(dragDistance > 20){
+                //This is to make sure that the second panel never overlaps with the first one
+                if(dragDistance > 15){
                     dragDir = -1;
                     peek_left();
-                } else if(dragDistance < -20){
+                } else if(dragDistance < -15){
                     dragDir = 1;
                     peek_right();
                 } else{
@@ -514,14 +515,16 @@ void level_select_loop() {
                 }
 
                 ui_set_pos_on_tag(&screen, 160 + dragDistance, LEVEL_CARD_Y_POS, "level_card");
-                ui_set_pos_on_tag(&screen, 160 + dragDistance + dragDir * 320, LEVEL_CARD_Y_POS, "level_card_2");
-            } else{
+                ui_set_pos_on_tag(&screen, 160 + dragDistance + (dragDir * 320), LEVEL_CARD_Y_POS, "level_card_2");
+            } else {
+                dragDir = 0;
+
                 int dragXDiff = touch.touchPosition.px - dragStartX;
                 if(abs(dragXDiff) > 10){
                     dragging = true;
                 }
-                lastTouchX = touch.touchPosition.px;
             }
+            lastTouchX = touch.touchPosition.px;
         }
         if((kUp & KEY_TOUCH)){
             if(dragging){
@@ -539,6 +542,12 @@ void level_select_loop() {
         }
 
         handle_card_movement();
+
+        //Buttons can't be tapped while dragging
+        if(dragging){
+            touch.touchPosition.px = -99;
+            touch.touchPosition.py = -99;
+        }
 
         ui_screen_update(&screen, &touch);
         ui_screen_update(&screen_top, &touch);


### PR DESCRIPTION
-You can no longer touch buttons while dragging on the level select screen
-Seemingly fixed the level panel overlapping issue 
-Buttons now only exclude debug keys during gameplay 
-L and R (or ZL and ZR) can now be used to navigate gamemode pages in the icon kit