### PR TITLE
More ui animations

### DIFF
--- a/romfs/menus/gameplay.txt
+++ b/romfs/menus/gameplay.txt
@@ -15,7 +15,7 @@ image x=90 y=20 id=15 sheet=1 tag="coin_3_full" scale=0.65
 button x=130 y=200 id=29 tag="practice_buttons,add_checkpoint,not_paused" action="add_check" keyBinds="LEFT,X"
 button x=200 y=200 id=154 tag="practice_buttons,remove_checkpoint,not_paused" action="remove_check" keyBinds="RIGHT,B"
 
-darken opacity=0.5 tag="paused"
+darken opacity=0.5 tag="paused" darkenTime=0.0
 button x=45 y=60 id=127 scale=1 tag="paused" action="settings" keyBinds="SELECT"
 
 button x=260 y=180 id=139 scale=1.15 tag="paused" action="unpause" keyBinds="A,START"

--- a/romfs/menus/level_complete.txt
+++ b/romfs/menus/level_complete.txt
@@ -1,4 +1,4 @@
-darken opacity=0.0 x=160 y=120 w=320 h=240 tag="endDarken"
+darken opacity=0.0 x=160 y=120 w=320 h=240 tag="endDarken" darkenTime=0.0
 
 button x=100 y=120 id=155 scale=1 action="restart" tag="bottomWindow" keyBinds="X"
 button x=220 y=120 id=111 scale=1 action="exit" tag="bottomWindow" keyBinds="B"

--- a/romfs/menus/level_complete_top.txt
+++ b/romfs/menus/level_complete_top.txt
@@ -1,4 +1,4 @@
-darken x=200 y=120 w=280 h=180 opacity=0.6 tag="window"
+darken x=200 y=120 w=280 h=180 opacity=0.6 tag="window,endDarken" darkenTime=0.0
 
 # chains (left, right)
 image x=80 y=-15 id=121 scale=1 sheet=3 tag="window"

--- a/romfs/menus/palette_kit.txt
+++ b/romfs/menus/palette_kit.txt
@@ -160,3 +160,5 @@ colorbutton x=231 y=205 scale=0.4 action="color_selected" tag="color"
 colorbutton x=246 y=205 scale=0.4 action="color_selected" tag="color"
 colorbutton x=261 y=205 scale=0.4 action="color_selected" tag="color"
 colorbutton x=276 y=205 scale=0.4 action="color_selected" tag="color"
+
+palleteicons tag="icons"

--- a/romfs/menus/statistics.txt
+++ b/romfs/menus/statistics.txt
@@ -1,4 +1,4 @@
-darken opacity=0.4
+darken x=0 y=0 opacity=0.4 darkenTime=0.5 tag="darken"
 
 # chains (left, right)
 image x=80 y=-4 id=121 scale=0.8 sheet=3 tag="window"

--- a/source/main.c
+++ b/source/main.c
@@ -445,6 +445,7 @@ void game_loop() {
     C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
     C2D_SceneBegin(top);
     C2D_TargetClear(top, C2D_Color32(0, 0, 0, 255));
+
     C2D_Fade(0);
     draw_text(&bigFont_fontCharset, &bigFont_sheet, SCREEN_WIDTH - 10, SCREEN_HEIGHT - 10, 0.5f, 0.5f, 1.0f, "Loading...");
     C3D_FrameEnd(0);
@@ -889,7 +890,7 @@ void game_loop() {
             // Top screen
             C2D_SceneBegin(top);
             C2D_TargetClear(top, C2D_Color32(0, 0, 0, 255));
-            
+
             draw_background(state.background_x / 8, -(state.camera_y / 8) + 200);
 
             C2D_ViewScale(SCALE, SCALE);

--- a/source/main.h
+++ b/source/main.h
@@ -77,6 +77,11 @@ typedef enum Cheats {
     CHEAT_COUNT
 } Cheats;
 
+typedef enum CurrentScreenTarget {
+    SCREEN_TOP,
+    SCREEN_BOTTOM
+} CurrentScreenTarget;
+
 extern bool cheats_used[CHEAT_COUNT];
 extern const char *cheat_names[CHEAT_COUNT];
 

--- a/source/menus/components/ui_darken.c
+++ b/source/menus/components/ui_darken.c
@@ -2,25 +2,43 @@
 #include <citro2d.h>
 #include "ui_screen.h"
 
+void ui_darken_reset_opacity(UIElement* e){
+    C2D_PlainImageTint(&e->darken.tint, C2D_Color32f(0, 0, 0, e->opacity), 1.0f);
+}
+
 static void ui_darken_update(UIElement* e, UIInput* touch) {
     bool inside = touch->touchPosition.px >= e->x - (e->w / 2) && touch->touchPosition.px < e->x + (e->w / 2) &&
                   touch->touchPosition.py >= e->y - (e->h / 2) && touch->touchPosition.py < e->y + (e->h / 2);
     
     // Mask background elements
     if (inside) touch->did_something = true;
+
+    if(e->darken.darkenTime <= 0.f){
+        e->opacity = e->darken.targetOpacity;
+        e->darken.darkenOver = true;
+    }
+
+    if(!e->darken.darkenOver){
+        e->opacity = (e->darken.darkenTimeElapsed / e->darken.darkenTime) * e->darken.targetOpacity;
+        e->darken.darkenTimeElapsed += 1.f / 60.f;
+    }
+
+    if(e->darken.darkenTimeElapsed > e->darken.darkenTime && !e->darken.darkenOver){
+        e->darken.darkenOver = true;
+    }
 }
 
 static void ui_darken_draw(UIElement* e) {
-    C2D_SpriteSetPos(&e->darken.sprite, e->x, e->y);
-    C2D_SpriteSetScale(&e->darken.sprite, e->w/16.f, e->h/16.f);
+    if(!e->darken.darkenOver){
+        ui_darken_reset_opacity(e);
+    }
+
+    C2D_SpriteSetPos(&e->darken.sprite, 200, 120);
+    C2D_SpriteSetScale(&e->darken.sprite, 400, 240);
     C2D_DrawSpriteTinted(&e->darken.sprite, &e->darken.tint);
 }
 
-void ui_darken_reset_opacity(UIElement* e){
-    C2D_PlainImageTint(&e->darken.tint, C2D_Color32f(0, 0, 0, e->opacity), 1.0f);
-}
-
-UIElement ui_create_darken(float x, float y, float width, float height, float opacity, char (*tag)[TAG_LENGTH]) {
+UIElement ui_create_darken(float x, float y, float width, float height, float opacity, float darkenTime, char (*tag)[TAG_LENGTH]) {
     UIElement e = {0};
 
     e.type = UI_DARKEN;
@@ -29,7 +47,12 @@ UIElement ui_create_darken(float x, float y, float width, float height, float op
     e.w = width;
     e.h = height;
     e.enabled = true;
-    e.opacity = opacity;
+    e.opacity = 0.0f;
+
+    e.darken.darkenTime = darkenTime;
+    e.darken.darkenTimeElapsed = 0.f;
+    e.darken.darkenOver = false;
+    e.darken.targetOpacity = opacity;
 
     // Copy tag
     copy_tag_array(&e, tag);

--- a/source/menus/components/ui_darken.h
+++ b/source/menus/components/ui_darken.h
@@ -2,4 +2,4 @@
 #include "ui_element.h"
 
 void ui_darken_reset_opacity(UIElement *e);
-UIElement ui_create_darken(float x, float y, float width, float height, float opacity, char (*tag)[TAG_LENGTH]);
+UIElement ui_create_darken(float x, float y, float width, float height, float opacity, float darkenTime, char (*tag)[TAG_LENGTH]);

--- a/source/menus/components/ui_element.h
+++ b/source/menus/components/ui_element.h
@@ -25,7 +25,8 @@ typedef enum {
     UI_EXTERNAL_LEVEL_CARD,
     UI_STATISTIC_CARD,
     UI_PARTICLE,
-    UI_USE_EFFECT
+    UI_USE_EFFECT,
+    UI_PALLETE_ICONS
 } UIElementType;
 
 typedef struct {
@@ -163,6 +164,10 @@ typedef struct {
 typedef struct {
     C2D_Sprite sprite;
     C2D_ImageTint tint;
+    float targetOpacity;
+    float darkenTime;
+    float darkenTimeElapsed;
+    bool darkenOver;
 } UIDarken;
 
 typedef struct {

--- a/source/menus/components/ui_list.c
+++ b/source/menus/components/ui_list.c
@@ -95,7 +95,7 @@ static void ui_list_draw(UIElement* e) {
 
     // Draw border
     C2D_DrawRectSolid(x, y, 0, e->w, e->h,
-                      C2D_Color32(40,40,40,255));
+    C2D_Color32(40,40,40,255));
 
     // Enable clipping
     set_scissor(GPU_SCISSOR_NORMAL, x, y, e->w, e->h);

--- a/source/menus/components/ui_pallete_icons.c
+++ b/source/menus/components/ui_pallete_icons.c
@@ -1,0 +1,42 @@
+#include "ui_element.h"
+#include <citro2d.h>
+#include "ui_screen.h"
+#include "ui_bg_gradient.h"
+#include "menus/palette_kit.h"
+#include "graphics.h"
+
+static void ui_pallete_icons_update(UIElement* e, UIInput* touch) {
+    bool inside = touch->touchPosition.px >= e->x - (e->w / 2) && touch->touchPosition.px < e->x + (e->w / 2) &&
+                  touch->touchPosition.py >= e->y - (e->h / 2) && touch->touchPosition.py < e->y + (e->h / 2);
+    
+    if (inside) touch->did_something = true;
+}
+
+static void ui_pallete_icons_draw(UIElement* e) {
+    bool glow_enabled = (player_glow_enabled || ((p1_color.r | p1_color.g | p1_color.b) == 0));
+    
+    for (size_t g = 0; g < GAMEMODE_COUNT; g++) {
+        spawn_icon_at(
+            g, *current_icons[g], glow_enabled, 90 + g * 35, 70, 0, 0, 0, 0.7f,
+            C2D_Color32(p1_color.r, p1_color.g, p1_color.b, 255),
+            C2D_Color32(p2_color.r, p2_color.g, p2_color.b, 255),
+            C2D_Color32(glow_color.r, glow_color.g, glow_color.b, 255)
+        );
+    }
+}
+
+UIElement ui_create_pallete_icons(char (*tag)[TAG_LENGTH]) {
+    UIElement e = {0};
+
+    e.type = UI_PALLETE_ICONS;
+    e.x = 0;
+    e.y = 0;
+    e.enabled = true;
+
+    copy_tag_array(&e, tag);
+
+    e.update = ui_pallete_icons_update;
+    e.draw = ui_pallete_icons_draw;
+
+    return e;
+}

--- a/source/menus/components/ui_pallete_icons.h
+++ b/source/menus/components/ui_pallete_icons.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "ui_element.h"
+#include <citro2d.h>
+#include "ui_screen.h"
+#include "ui_bg_gradient.h"
+#include "menus/palette_kit.h"
+
+UIElement ui_create_pallete_icons(char (*tag)[TAG_LENGTH]);

--- a/source/menus/components/ui_particle.h
+++ b/source/menus/components/ui_particle.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "ui_element.h"
 #include "particles/particle_definitions.h"
 

--- a/source/menus/components/ui_screen.c
+++ b/source/menus/components/ui_screen.c
@@ -18,6 +18,7 @@
 #include "ui_particle.h"
 #include "ui_use_effect.h"
 #include "particles/particle_definitions.h"
+#include "ui_pallete_icons.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -41,7 +42,9 @@ C2D_SpriteSheet goldFont_sheet;
 C2D_SpriteSheet bg_gradient_sheet;
 C2D_SpriteSheet bar_sheet;
 
-UIScreen default_screen;
+UIScreen default_screen = {
+    .isBottom = true
+};
 UIScreen default_screen_top;
 
 ParticleSystem *uiParticleSystems[UI_MAX_PARTICLE_SYSTEMS];
@@ -111,8 +114,40 @@ C2D_SpriteSheet *get_sheet(int sheet) {
     return NULL;
 }
 
+void run_animation_slide(UIScreen *screen, bool go_up) {
+    float fade_value = easeValue(EASE_IN_OUT, go_up ? 240 : 0, go_up ? 0 : 240, screen->open_anim_time, 0.5f, 2.0f);
+    float window_y_pos = -120 + fade_value;
+    
+    bool found_parent = false;
+    float movement_y = 0;
+    for (int i = 0; i < screen->count; i++) {
+        UIElement *e = &screen->elements[i];
+
+        if (!found_parent) {
+            found_parent = true;
+            movement_y = window_y_pos - e->y;
+        }
+
+        e->y += movement_y;
+    }
+
+    if(screen->open_anim_time >= 0.5f){
+        screen->open_anim_time = 0.5f;
+        screen->open_anim_done = true;
+    }
+}
+
 // Update all screen characters
 void ui_screen_update(UIScreen* s, UIInput* touch) {
+    if (s->open_anim_time >= 1.f) {
+        s->open_anim_time = 1.f;
+        s->open_anim_done = true;
+    }
+
+    if(!s->open_anim_done) s->open_anim_time += 1.f / 60.f;
+    
+    if(s->disable_element_update) return;
+
     for (int i = s->count - 1; i >= 0; i--) {
         UIElement *e = &s->elements[i];
         if (e->enabled) e->update(e, touch);
@@ -121,10 +156,52 @@ void ui_screen_update(UIScreen* s, UIInput* touch) {
 
 // Draw all screen characters
 void ui_screen_draw(UIScreen* s) {
+    C3D_Mtx originalMat;
+    C3D_Mtx newMat;
+    C2D_ViewSave(&originalMat);
+
+    float offX = 0.f;
+    float offY = 0.f;
+
+    if(!s->open_anim_done){
+        int width = s->isBottom ? 320 : 400;
+        int height = 240;
+
+        if(s->open_anim == ANIM_ZOOM) {
+            float scale_value = easeValue(ELASTIC_OUT, 0.f, 1.f, s->open_anim_time, 0.5f, 1.f);
+
+            float cx = width * 0.5f;
+            float cy = height * 0.5f;
+
+            C2D_ViewTranslate(cx, cy);
+            C2D_ViewScale(scale_value, scale_value);
+            C2D_ViewTranslate(-cx, -cy);
+        } else if(s->open_anim == ANIM_SLIDE_RIGHT) {
+            float slide_value = easeValue(ELASTIC_OUT, 0.f, 1.f, s->open_anim_time, 0.5f, 1.f);
+
+            offX = -(1.f - slide_value) * (width / 2.f);
+        }
+    }
+
+    C2D_ViewTranslate(offX, offY);
+
+    C2D_ViewSave(&newMat);
+
     for (int i = 0; i < s->count; i++) {
         UIElement *e = &s->elements[i];
+
+        if(e->type == UI_DARKEN) {
+            C2D_ViewRestore(&originalMat);
+        }
+
         if (e->enabled) e->draw(e);
+
+        if(e->type == UI_DARKEN){
+            C2D_ViewRestore(&newMat);
+        }
     }
+
+    C2D_ViewRestore(&originalMat);
 }
 
 // Find an action by its name
@@ -313,6 +390,10 @@ void ui_load_screen(UIScreen* screen,
     FILE* f = fopen(path, "r");
     if (!f) return;
 
+    screen->disable_element_update = false;
+    screen->open_anim_time = 0.f;
+    screen->open_anim_done = false;
+
     screen->count = 0;
 
     char line[512];
@@ -365,6 +446,8 @@ void ui_load_screen(UIScreen* screen,
         const ParticleDefinition *particleDef = &firework;
 
         u32 keyBinds = 0;
+
+        float darkenTime = 0.1f;
 
         // Parse element parameters
         while ((token = next_token(&cursor)) != NULL) {
@@ -506,6 +589,8 @@ void ui_load_screen(UIScreen* screen,
                         particleDef = particleDefNames[i].def;
                     }
                 }
+            } else if(strcmp(key, "darkenTime") == 0){
+                darkenTime = atof(value);
             }
         }
 
@@ -577,7 +662,7 @@ void ui_load_screen(UIScreen* screen,
             }
             screen->elements[screen->count++] =
                 ui_create_darken(
-                    x, y, w, h, opacity, tag
+                    x, y, w, h, opacity, darkenTime, tag
                 );
         } else if (strcmp(type, "icon") == 0) {
             screen->elements[screen->count++] =
@@ -619,6 +704,9 @@ void ui_load_screen(UIScreen* screen,
         } else if (strcmp(type, "useeffect") == 0) {
             screen->elements[screen->count++] =
                 ui_create_use_effect(tag);
+        } else if (strcmp(type, "palleteicons") == 0) {
+            screen->elements[screen->count++] =
+                ui_create_pallete_icons(tag);
         }
     }
 

--- a/source/menus/components/ui_screen.h
+++ b/source/menus/components/ui_screen.h
@@ -5,9 +5,22 @@
 #define UI_MAX_ELEMENTS 128
 #define UI_MAX_PARTICLE_SYSTEMS 32
 
+typedef enum {
+    ANIM_NONE,
+    ANIM_ZOOM,
+    ANIM_SLIDE_RIGHT,
+
+    NUM_OPEN_ANIMS
+} ScreenOpenAnim;
+
 typedef struct {
     UIElement elements[UI_MAX_ELEMENTS];
     int count;
+    float open_anim_time;
+    bool open_anim_done;
+    ScreenOpenAnim open_anim;
+    bool isBottom;
+    bool disable_element_update;
 } UIScreen;
 
 typedef struct {
@@ -50,6 +63,8 @@ C2D_SpriteSheet *get_sheet(int sheet);
 void copy_tag_array(UIElement *e, char (*tag)[TAG_LENGTH]);
 void ui_load_screen(UIScreen* screen, const UIAction* actions, size_t count, const char* path);
 void ui_unload_screen(UIScreen *screen);
+
+void run_animation_slide(UIScreen *screen, bool go_up);
 
 void ui_screen_update(UIScreen* screen, UIInput* touch);
 void ui_screen_draw(UIScreen* screen);

--- a/source/menus/components/ui_use_effect.h
+++ b/source/menus/components/ui_use_effect.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "ui_element.h"
 #include <citro2d.h>
 #include "ui_screen.h"

--- a/source/menus/credits.c
+++ b/source/menus/credits.c
@@ -19,7 +19,10 @@
 
 static bool yes_exit = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true,
+    .open_anim = ANIM_ZOOM
+};
 
 void exit_credits(UIElement* e) {
     yes_exit = true;

--- a/source/menus/external_level_infobox.c
+++ b/source/menus/external_level_infobox.c
@@ -15,7 +15,10 @@
 
 static bool yes_exit = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true,
+    .open_anim = ANIM_ZOOM
+};
 
 static UIElement *name;
 

--- a/source/menus/external_levels.c
+++ b/source/menus/external_levels.c
@@ -49,7 +49,9 @@ static bool first_time_loaded = true;
 
 static bool in_external_popup = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true
+};
 static UIScreen screen_top;
 static UIElement *bg_gradient;
 static UIElement *bg_gradient_top;

--- a/source/menus/external_popup.c
+++ b/source/menus/external_popup.c
@@ -33,8 +33,13 @@ static bool yes_exit = false;
 
 static bool in_infobox = false;
 
-static UIScreen screen_top;
-static UIScreen screen;
+static UIScreen screen_top = {
+    .open_anim = ANIM_ZOOM
+};
+static UIScreen screen = {
+    .isBottom = true,
+    .open_anim = ANIM_ZOOM
+};
 
 static UIElement *level_name;
 static UIElement *creator_name;

--- a/source/menus/first_boot_disclaimer.c
+++ b/source/menus/first_boot_disclaimer.c
@@ -22,7 +22,9 @@
 static bool yes_exit = false;
 bool initialDisclaimerAccepted = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true
+};
 
 void exit_first_boot_disclaimer(UIElement* e) {
     initialDisclaimerAccepted = true;

--- a/source/menus/generic_disclaimer.c
+++ b/source/menus/generic_disclaimer.c
@@ -19,7 +19,9 @@
 
 static bool yes_exit = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true
+};
 
 void exit_disclaimer(UIElement* e) {
     yes_exit = true;

--- a/source/menus/info_card.c
+++ b/source/menus/info_card.c
@@ -22,7 +22,9 @@
 
 static bool yes_exit = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true
+};
 static UIElement *content;
 
 void exit_info_card(UIElement* e) {

--- a/source/menus/level_complete.c
+++ b/source/menus/level_complete.c
@@ -58,7 +58,9 @@ static bool playedRewardSFX;
 static bool showStars;
 
 static UIScreen screen_top;
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true
+};
 
 static UIElement *attempt_text;
 static UIElement *jumps_text;
@@ -126,6 +128,7 @@ static void exit_level_complete(UIElement* e) {
 static void restart_level(UIElement* e) {
     if (!animating_up) {
         ui_get_element_by_tag(&screen, "endDarken")->opacity = 0.f;
+        ui_get_element_by_tag(&screen_top, "endDarken")->opacity = 0.f;
         
         play_sfx(&play_sound, 1);
         animating_up = true;
@@ -155,6 +158,10 @@ static void run_start_animation(float delta) {
     UIElement *darken = ui_get_element_by_tag(&screen, "endDarken");
     darken->opacity = clampf(anim_time, 0.f, 0.6f);
     ui_darken_reset_opacity(darken);
+
+    UIElement *darken_top = ui_get_element_by_tag(&screen_top, "endDarken");
+    darken_top->opacity = clampf(anim_time, 0.f, 0.6f);
+    ui_darken_reset_opacity(darken_top);
 
     ui_run_func_on_tag(&screen, "bottomWindow", scale_bottom_buttons_anim);
     
@@ -462,6 +469,7 @@ void level_complete_init() {
     }
 
     ui_get_element_by_tag(&screen, "endDarken")->opacity = 0.f;
+    ui_get_element_by_tag(&screen_top, "endDarken")->opacity = 0.f;
 }
 
 int level_complete_loop(float delta) {

--- a/source/menus/palette_kit.c
+++ b/source/menus/palette_kit.c
@@ -22,7 +22,10 @@
 
 static bool yes_exit = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true,
+    .open_anim = ANIM_SLIDE_RIGHT
+};
 
 const u32 colors[] = {
     // Reds
@@ -266,16 +269,6 @@ int palette_kit_loop() {
     touch.interacted = false;
     ui_screen_update(&screen, &touch);
     ui_screen_draw(&screen);
-    bool glow_enabled = (player_glow_enabled || ((p1_color.r | p1_color.g | p1_color.b) == 0));
-    
-    for (size_t g = 0; g < GAMEMODE_COUNT; g++) {
-        spawn_icon_at(
-            g, *current_icons[g], glow_enabled, 90 + g * 35, 70, 0, 0, 0, 0.7f,
-            C2D_Color32(p1_color.r, p1_color.g, p1_color.b, 255),
-            C2D_Color32(p2_color.r, p2_color.g, p2_color.b, 255),
-            C2D_Color32(glow_color.r, glow_color.g, glow_color.b, 255)
-        );
-    }
 
     return false;
 }

--- a/source/menus/settings.c
+++ b/source/menus/settings.c
@@ -24,7 +24,10 @@ static bool yes_exit = false;
 
 static int current_page = 0;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true,
+    .open_anim = ANIM_ZOOM
+};
 
 bool particlesDisabled = false;
 bool wideEnabled = false;

--- a/source/menus/statistics.c
+++ b/source/menus/statistics.c
@@ -18,12 +18,16 @@
 #include "main_menu.h"
 #include "level_select.h"
 #include "statistics.h"
+#include "menus/components/ui_darken.h"
 
 #include "save/saving.h"
 
 static bool yes_exit = false;
+static bool exiting = false;
 
-static UIScreen screen;
+static UIScreen screen = {
+    .isBottom = true
+};
 
 static UIElement *list;
 
@@ -49,11 +53,15 @@ static const StatisticEntries stats[] = {
 UIElement entries[NUM_STATS_ENTRIES];
 
 void exit_statistics(UIElement* e) {
-    yes_exit = true;
+    //start exit animation
+    screen.open_anim_done = false;
+    screen.open_anim_time = 0.5f - screen.open_anim_time;
+    exiting = true;
+    screen.disable_element_update = true;
 }
 
 static UIAction actions[] = {
-    { "exit", exit_statistics },
+    { "exit", exit_statistics }
 };
 
 void statistics_init() {
@@ -71,10 +79,20 @@ void statistics_init() {
         }
     }
 
+    exiting = false;
     yes_exit = false;
 }
 
 int statistics_loop() {
+    if(exiting){
+        UIElement *darken = ui_get_element_by_tag(&screen, "darken");
+        darken->opacity = ((0.5f - screen.open_anim_time) * 2.f) * darken->darken.targetOpacity;
+        ui_darken_reset_opacity(darken);
+        if(screen.open_anim_done){
+            yes_exit = true;
+        }
+    }
+
     if (yes_exit) {
         ui_unload_screen(&screen);
         return true;
@@ -86,7 +104,10 @@ int statistics_loop() {
     touch.touchPosition = touchPos;
     touch.did_something = false;
     touch.interacted = false;
+
     ui_screen_update(&screen, &touch);
+
+    run_animation_slide(&screen, exiting);
 
     ui_screen_draw(&screen);
 


### PR DESCRIPTION
-Screens can now have an animation play when opened (zoom in or slide in from the left)
-Statistics menu (and eventual settings/achievement menu) now slides down when opened and up when closed
-The darkened BG that appears when opening a new menu now fades in smoothly for most menus