### PR TITLE
Redesign palette kit menu

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -8,7 +8,11 @@
                 "/opt/devkitpro/devkitARM/arm-none-eabi/include",
                 "/opt/devkitpro/devkitARM/lib/gcc/arm-none-eabi/*/include",
                 "/opt/devkitpro/portlibs/3ds/include",
-                "${workspaceFolder}/libraries"
+                "${workspaceFolder}/libraries",
+                "C:/devkitpro/libctru/include",
+                "C:/devkitpro/devkitARM/arm-none-eabi/include",
+                "C:/devkitpro/devkitARM/bin/gcc/arm-none-eabi/*/include",
+                "C:/devkitpro/portlibs/3ds/include"
             ],
             "defines": [
                 "__3DS__"

--- a/romfs/menus/palette_kit.txt
+++ b/romfs/menus/palette_kit.txt
@@ -3,162 +3,49 @@ window x=160 y=120 w=260 h=200 style=3
 button x=40 y=30 id=31 scale=0.8 action="exit" keyBinds="B"
 window x=160 y=70 w=200 h=40 style=2 tag="bg_window"
 
-windowbutton x=155 y=38 w=45 h=20 style=5 text="Col1" tag="color_buttons,p1" action="action_p1" textScale=0.4
-windowbutton x=203 y=38 w=45 h=20 style=4 text="Col2" tag="color_buttons,p2" action="action_p2" textScale=0.4
-windowbutton x=251 y=38 w=45 h=20 style=4 text="Glow" tag="color_buttons,glow" action="action_glow" textScale=0.4
+windowbutton x=92 y=38 w=65 h=20 style=5 text="Color 1" hoverFactor=0.5 tag="color_buttons,p1" action="action_p1" textScale=0.4
+windowbutton x=160 y=38 w=65 h=20 style=4 text="Color 2" hoverFactor=0.5 tag="color_buttons,p2" action="action_p2" textScale=0.4
+windowbutton x=228 y=38 w=65 h=20 style=4 text="Glow" hoverFactor=0.5 tag="color_buttons,glow" action="action_glow" textScale=0.4
 
-checkbox x=50 y=205 scale=0.5 action="glow" tag="glow_option,chk_glow" 
-label x=60 y=205 text="Glow" scale=0.4 tag="glow_option"
+checkbox x=50 y=200 scale=0.7 action="glow" tag="glow_option,check_glow" 
+label x=65 y=200 text="Glow" scale=0.6 tag="glow_option"
 
-# Reds
+#Categories
 
-colorbutton x=45 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=60 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=75 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=90 y=105 scale=0.4 action="color_selected" tag="color"
+colorbutton x=63 y=112 scale=0.7 action="category_selected" tag="category"
+colorbutton x=90 y=112 scale=0.7 action="category_selected" tag="category"
+colorbutton x=117 y=112 scale=0.7 action="category_selected" tag="category"
+colorbutton x=144 y=112 scale=0.7 action="category_selected" tag="category"
 
-colorbutton x=45 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=60 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=75 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=90 y=120 scale=0.4 action="color_selected" tag="color"
+colorbutton x=63 y=139 scale=0.7 action="category_selected" tag="category"
+colorbutton x=90 y=139 scale=0.7 action="category_selected" tag="category"
+colorbutton x=117 y=139 scale=0.7 action="category_selected" tag="category"
+colorbutton x=144 y=139 scale=0.7 action="category_selected" tag="category"
 
-colorbutton x=45 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=60 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=75 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=90 y=135 scale=0.4 action="color_selected" tag="color"
+colorbutton x=63 y=166 scale=0.7 action="category_selected" tag="category"
 
-# Oranges
+#Colors 
 
-colorbutton x=107 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=122 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=137 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=152 y=105 scale=0.4 action="color_selected" tag="color"
+window x=217 y=152 w=115 h=115 style=2 tag="color_window"
 
-colorbutton x=107 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=122 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=137 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=152 y=120 scale=0.4 action="color_selected" tag="color"
+colorbutton x=176 y=112 scale=0.7 action="color_selected" tag="color"
+colorbutton x=203 y=112 scale=0.7 action="color_selected" tag="color"
+colorbutton x=230 y=112 scale=0.7 action="color_selected" tag="color"
+colorbutton x=257 y=112 scale=0.7 action="color_selected" tag="color"
 
-colorbutton x=107 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=122 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=137 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=152 y=135 scale=0.4 action="color_selected" tag="color"
+colorbutton x=176 y=139 scale=0.7 action="color_selected" tag="color"
+colorbutton x=203 y=139 scale=0.7 action="color_selected" tag="color"
+colorbutton x=230 y=139 scale=0.7 action="color_selected" tag="color"
+colorbutton x=257 y=139 scale=0.7 action="color_selected" tag="color"
 
-# Yellows
+colorbutton x=176 y=166 scale=0.7 action="color_selected" tag="color"
+colorbutton x=203 y=166 scale=0.7 action="color_selected" tag="color"
+colorbutton x=230 y=166 scale=0.7 action="color_selected" tag="color"
+colorbutton x=257 y=166 scale=0.7 action="color_selected" tag="color"
 
-colorbutton x=169 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=184 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=199 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=214 y=105 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=169 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=184 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=199 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=214 y=120 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=169 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=184 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=199 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=214 y=135 scale=0.4 action="color_selected" tag="color"
-
-# Greens
-
-colorbutton x=231 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=246 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=261 y=105 scale=0.4 action="color_selected" tag="color"
-colorbutton x=276 y=105 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=231 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=246 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=261 y=120 scale=0.4 action="color_selected" tag="color"
-colorbutton x=276 y=120 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=231 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=246 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=261 y=135 scale=0.4 action="color_selected" tag="color"
-colorbutton x=276 y=135 scale=0.4 action="color_selected" tag="color"
-
-# Cyans
-
-colorbutton x=45 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=60 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=75 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=90 y=152 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=45 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=60 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=75 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=90 y=167 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=45 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=60 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=75 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=90 y=182 scale=0.4 action="color_selected" tag="color"
-
-# Blues
-
-colorbutton x=107 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=122 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=137 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=152 y=152 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=107 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=122 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=137 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=152 y=167 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=107 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=122 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=137 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=152 y=182 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=107 y=197 scale=0.4 action="color_selected" tag="color"
-colorbutton x=122 y=197 scale=0.4 action="color_selected" tag="color"
-colorbutton x=137 y=197 scale=0.4 action="color_selected" tag="color"
-colorbutton x=152 y=197 scale=0.4 action="color_selected" tag="color"
-
-# Purples
-
-colorbutton x=169 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=184 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=199 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=214 y=152 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=169 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=184 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=199 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=214 y=167 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=169 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=184 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=199 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=214 y=182 scale=0.4 action="color_selected" tag="color"
-
-# Magentas
-
-colorbutton x=231 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=246 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=261 y=152 scale=0.4 action="color_selected" tag="color"
-colorbutton x=276 y=152 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=231 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=246 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=261 y=167 scale=0.4 action="color_selected" tag="color"
-colorbutton x=276 y=167 scale=0.4 action="color_selected" tag="color"
-
-colorbutton x=231 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=246 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=261 y=182 scale=0.4 action="color_selected" tag="color"
-colorbutton x=276 y=182 scale=0.4 action="color_selected" tag="color"
-
-# Grayscale
-
-colorbutton x=186 y=205 scale=0.4 action="color_selected" tag="color"
-colorbutton x=201 y=205 scale=0.4 action="color_selected" tag="color"
-colorbutton x=216 y=205 scale=0.4 action="color_selected" tag="color"
-colorbutton x=231 y=205 scale=0.4 action="color_selected" tag="color"
-colorbutton x=246 y=205 scale=0.4 action="color_selected" tag="color"
-colorbutton x=261 y=205 scale=0.4 action="color_selected" tag="color"
-colorbutton x=276 y=205 scale=0.4 action="color_selected" tag="color"
+colorbutton x=176 y=193 scale=0.7 action="color_selected" tag="color"
+colorbutton x=203 y=193 scale=0.7 action="color_selected" tag="color"
+colorbutton x=230 y=193 scale=0.7 action="color_selected" tag="color"
+colorbutton x=257 y=193 scale=0.7 action="color_selected" tag="color"
 
 paletteicons x=160 y=70 scale=0.7 tag="icons"

--- a/source/menus/components/ui_color_button.c
+++ b/source/menus/components/ui_color_button.c
@@ -43,8 +43,6 @@ static void ui_color_button_draw(UIElement* e, UITransform *transform) {
 
 void ui_color_button_set_index(UIColor *e, int index, int color_index) {
     if (!e) return;
-
-    e->isSelected = *current_colors[index] == color_index,
     e->index = index;
     e->color_index = color_index;
 }

--- a/source/menus/palette_kit.c
+++ b/source/menus/palette_kit.c
@@ -10,6 +10,7 @@
 #include "menus/components/ui_window_button.h"
 #include "graphics.h"
 #include "palette_kit.h"
+#include "menus/components/ui_checkbox.h"
 
 static bool yes_exit = false;
 
@@ -163,8 +164,56 @@ const u32 colors[] = {
 
 const size_t NUM_COLORS = ARRAY_LEN(colors);
 
+/*
+Categories:
+
+Red,
+Orange,
+Yellow,
+Green,
+Cyan,
+Blue,
+Purple,
+Magenta,
+Gray
+*/
+static int category_colors[] = {
+    3,
+    15,
+    26,
+    39,
+    51,
+    63,
+    78,
+    89,
+    103
+};
+
+//amount of colors in each category
+static int category_counts[] = {
+    12,
+    12,
+    12,
+    12,
+    12,
+    16,
+    12,
+    12,
+    7
+};
+
+static int selected_category;
+
+//the first color index in the selected category
+static int starting_color_index;
+
+//used to increment category color buttons during setup
+static int category_counter = 0;
+
+//used to increment color buttons during setup
 static int color_counter = 0;
 
+//color 1, 2, or glow
 static int color_page = 0;
 
 static void disable_glow_setting(UIElement *e) {
@@ -177,16 +226,71 @@ static void enable_glow_setting(UIElement *e) {
 
 static void set_color_index(UIElement *e) {
     UIColor *color = (UIColor *) e;
-    ui_color_button_set_index(color, color_page, color_counter);
+
+    int color_index = starting_color_index + color_counter;
+
+    ui_color_button_set_index(color, color_page, color_index);
+
+    color->isSelected = *current_colors[color_page] == color_index;
+
+    e->enabled = color_counter < category_counts[selected_category];
+
     color_counter++;
+}
+
+static void set_category_index(UIElement *e) {
+    UIColor *color = (UIColor *) e;
+    //rather than using the color index as col1/col2/glow, it's used as a category index for the button
+    ui_color_button_set_index(color, category_counter, category_colors[category_counter]);
+    
+    color->isSelected = selected_category == category_counter;
+    
+    category_counter++;
+}
+
+static void reset_indices(){
+    category_counter = 0;
+    color_counter = 0;
+
+    //get selected category from selected color index
+    int current_index = *current_colors[color_page];
+
+    //9 is the number of categories
+    for(int i = 0; i < 9; i++){
+        if(current_index < category_counts[i]){
+            selected_category = i;
+            break;
+        }
+        current_index -= category_counts[i];
+    }
+
+    //find first color index
+    starting_color_index = 0;
+    for(int i = 0; i < selected_category; i++){
+        starting_color_index += category_counts[i];
+    }
+
+    ui_run_func_on_tag(&screen, "category", set_category_index);
+    ui_run_func_on_tag(&screen, "color", set_color_index);
+}
+
+static void action_category_selected(UIElement *e){
+    UIColor *color = (UIColor *) e;
+
+    //The index of the category color buttons does not correspond to col1/col2/glow, instead corresponding to its category
+    *current_colors[color_page] = category_colors[color->index];
+    update_player_colors();
+
+    reset_indices();
 }
 
 static void action_color_selected(UIElement *e) {
     UIColor *color = (UIColor *) e;
+
     *current_colors[color_page] = color->color_index;
     update_player_colors();
-    color_counter = 0;
-    ui_run_func_on_tag(&screen, "color", set_color_index);
+
+    reset_indices();
 }
 
 void exit_palette_kit(UIElement* e) {
@@ -201,27 +305,24 @@ static void set_p1_page(UIElement *e) {
     ui_run_func_on_tag(&screen, "color_buttons", disable_all_color_buttons);
     ui_window_button_set_style((UIWindowButton *) e, 5);
     color_page = 0;
-    color_counter = 0;
     ui_run_func_on_tag(&screen, "glow_option", disable_glow_setting);
-    ui_run_func_on_tag(&screen, "color", set_color_index);
+    reset_indices();
 }
 
 static void set_p2_page(UIElement *e) {
     ui_run_func_on_tag(&screen, "color_buttons", disable_all_color_buttons);
     ui_window_button_set_style((UIWindowButton *) e, 5);
     color_page = 1;
-    color_counter = 0;
     ui_run_func_on_tag(&screen, "glow_option", disable_glow_setting);
-    ui_run_func_on_tag(&screen, "color", set_color_index);
+    reset_indices();
 }
 
 static void set_glow_page(UIElement *e) {
     ui_run_func_on_tag(&screen, "color_buttons", disable_all_color_buttons);
     ui_window_button_set_style((UIWindowButton *) e, 5);
     color_page = 2;
-    color_counter = 0;
     ui_run_func_on_tag(&screen, "glow_option", enable_glow_setting);
-    ui_run_func_on_tag(&screen, "color", set_color_index);
+    reset_indices();
 }
 
 void player_glow_settings(UIElement* e) {
@@ -235,7 +336,8 @@ static UIAction actions[] = {
     {"action_p1", set_p1_page},
     {"action_p2", set_p2_page},
     {"action_glow", set_glow_page},
-    {"glow", player_glow_settings}
+    {"glow", player_glow_settings},
+    {"category_selected", action_category_selected}
 };
 
 
@@ -244,11 +346,14 @@ void palette_kit_init() {
     ui_screen_open(&screen, ANIM_SLIDE_RIGHT);
     yes_exit = false;
     ui_window_set_tint((UIWindow *) ui_get_element_by_tag(&screen, "bg_window"), C2D_Color32(0, 0, 0, 64));
-    color_counter = 0;
+    ui_window_set_tint((UIWindow *) ui_get_element_by_tag(&screen, "color_window"), C2D_Color32(0, 0, 0, 64));
+
     color_page = 0;
-    ui_run_func_on_tag(&screen, "color", set_color_index);
+
+    reset_indices();
+
+    set_checkbox_enabled((UICheckBox *) ui_get_element_by_tag(&screen, "check_glow"), player_glow_enabled);
     ui_run_func_on_tag(&screen, "glow_option", disable_glow_setting);
-    ((UICheckBox *) ui_get_element_by_tag(&screen, "chk_glow"))->checked = player_glow_enabled;
 }
 
 int palette_kit_loop() {


### PR DESCRIPTION
-Colors are now selected by category and are now much larger and easier to select
-Color 1/Color 2/Glow buttons are now larger and centered
-Glow checkbox is larger and now properly checks/unchecks when the menu is reopened