### PR TITLE
Added 240Hz input (plus song filter null terminator string fix)

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -526,12 +526,6 @@ void init_particles(Color p1_color, Color p2_color) {
     level_complete_effect_p2.cfg.finishColorBlue  = p2_not_white.b / 255.f;
 }
 
-// Empty on purpose: a stable target for `break cbf_click_hook` in GDB.
-// noinline keeps it a real call at -O2; the asm keeps the call from being elided.
-__attribute__((noinline)) void cbf_click_hook(u32 slot, u32 samples_ago, u32 pressed, u32 released) {
-    __asm__ volatile("" ::: "memory");
-}
-
 void game_loop() {
 #ifdef DEBUG_LEAKS
     current_generation++;
@@ -1271,7 +1265,6 @@ int main(int argc, char* argv[]) {
     // Init libs
     romfsInit();
     gfxInitDefault();
-    consoleDebugInit(debugDevice_SVC);
     C3D_Init(C3D_DEFAULT_CMDBUF_SIZE * 4);
     C2D_Init(MAX_SPRITES);
     C2D_Prepare();

--- a/source/main.c
+++ b/source/main.c
@@ -56,6 +56,8 @@
 
 #include "math_helpers.h"
 
+#include "utils/precise_input.h"
+
 #ifdef DEBUG_LEAKS
 #include "utils/leaks_dbg.h"
 #endif
@@ -85,6 +87,11 @@ const char *cheat_names[CHEAT_COUNT] = {
 
 float accumulator = 0.f;
 bool fixed_dt = true;
+
+#define TARGET_FPS 60
+#define PI_SUBSTEP_BUCKETS (STEPS_HZ / TARGET_FPS)
+
+u32 pi_substep_presses[PI_SUBSTEP_BUCKETS];
 
 PrintConsole console;
 
@@ -519,6 +526,12 @@ void init_particles(Color p1_color, Color p2_color) {
     level_complete_effect_p2.cfg.finishColorBlue  = p2_not_white.b / 255.f;
 }
 
+// Empty on purpose: a stable target for `break cbf_click_hook` in GDB.
+// noinline keeps it a real call at -O2; the asm keeps the call from being elided.
+__attribute__((noinline)) void cbf_click_hook(u32 slot, u32 samples_ago, u32 pressed, u32 released) {
+    __asm__ volatile("" ::: "memory");
+}
+
 void game_loop() {
 #ifdef DEBUG_LEAKS
     current_generation++;
@@ -580,6 +593,10 @@ void game_loop() {
     exiting_level = false;
     fixed_dt = true;
 
+    pi_set_jump_keys((settingsState.yJump ? KEY_Y : KEY_A) | KEY_UP);
+    pi_reset();
+    memset(pi_substep_presses, 0, sizeof(pi_substep_presses));
+
     u64 lastTime = svcGetSystemTick();
     u64 start = svcGetSystemTick();
     bool old_wide = settingsState.wideEnabled;
@@ -589,6 +606,8 @@ void game_loop() {
     while (aptMainLoop()) {
         start = svcGetSystemTick();
         hidScanInput();
+
+        pi_poll();
         
         touchPosition touchPos;
         hidTouchRead(&touchPos);
@@ -651,9 +670,14 @@ void game_loop() {
         bool buttonPressed = (settingsState.yJump ? (kDown & KEY_Y) : (kDown & KEY_A)) || (kDown & KEY_UP);
         bool buttonHeld = (settingsState.yJump ? (kHeld & KEY_Y) : (kHeld & KEY_A)) || (kHeld & KEY_UP);
 
-        state.old_input = state.input;
-        state.input.pressedJump = (buttonPressed || (in_bounds && (kDown & KEY_TOUCH))) == true;
-        state.input.holdJump = (state.input.pressedJump || buttonHeld || (in_bounds && (kHeld & KEY_TOUCH))) == true;
+        bool touch_pressed = in_bounds && (kDown & KEY_TOUCH);
+        bool touch_held = in_bounds && (kHeld & KEY_TOUCH);
+
+        if (!pi_enabled) {
+            state.old_input = state.input;
+            state.input.pressedJump = (buttonPressed || touch_pressed) == true;
+            state.input.holdJump = (state.input.pressedJump || buttonHeld || touch_held) == true;
+        }
         
         for (int i = 0; i < 2; i++) {
             drag_particles[i].emitting = false;
@@ -668,6 +692,7 @@ void game_loop() {
 
         u64 now = svcGetSystemTick();
         delta = (now - lastTime) / (CPU_TICKS_PER_MSEC * 1000);
+        u64 frame_window_start = lastTime;
         lastTime = now;
 
         if (state.death_timer <= 0)  {
@@ -695,12 +720,27 @@ void game_loop() {
                     if (!being_faded) fixed_dt = false;
                 }
                 accumulator += physics_delta;
+
+                u32 planned = (u32)(accumulator / STEPS_DT_UNMOD);
+                pi_begin_frame((u32)frame_window_start, (u32)now, planned ? planned : 1);
+
                 // Run simulation in fixed steps
                 while (accumulator >= STEPS_DT_UNMOD) {
                     u64 start_physics = svcGetSystemTick();
+
+                    if (pi_enabled) {
+                        pi_apply_substep((u32)steps);
+                        state.old_input = state.input;
+                        state.input.pressedJump = (pi_pressed() || touch_pressed) == true;
+                        state.input.holdJump = (pi_hold() || state.input.pressedJump || touch_held) == true;
+                        if (pi_pressed()){
+                            pi_substep_presses[steps < PI_SUBSTEP_BUCKETS ? steps : PI_SUBSTEP_BUCKETS - 1]++;
+                        }
+                    }
+
                     state.current_player = 0;
                     state.old_player = state.player;
-                    
+
                     trail = &trail_p1;
                     wave_trail = &wave_trail_p1;
                     handle_player(&state.player);
@@ -820,7 +860,8 @@ void game_loop() {
                     }
 
                     if (song_loaded) unpause_playback_mp3();
-                    fixed_dt = true; 
+                    pi_reset();
+                    fixed_dt = true;
                     state.dead = false;
                     state.hitbox_display = 0;
                 }
@@ -1094,6 +1135,9 @@ void game_loop() {
 
                 draw_text(&bigFont_fontCharset, &bigFont_sheet, 0,   114,  DEBUG_TEXT_SCALE, 0, true, "Touch:  %d, %d", touchPos.px, touchPos.py);
 
+                // im jut going to assume 60fps for this (4 buckets)
+                draw_text(&bigFont_fontCharset, &bigFont_sheet, 0,   126,  DEBUG_TEXT_SCALE, 0, true, "InputTicks: %d|%d|%d|%d", (int)pi_substep_presses[0], (int)pi_substep_presses[1], (int)pi_substep_presses[2], (int)pi_substep_presses[3]);
+
                 draw_text(&bigFont_fontCharset, &bigFont_sheet, 0,   138,  DEBUG_TEXT_SCALE, 0, true, "Player");
                 draw_text(&bigFont_fontCharset, &bigFont_sheet, 0,   150,  DEBUG_TEXT_SCALE, 0, true, "- Tick: %d", state.player.frame);
                 draw_text(&bigFont_fontCharset, &bigFont_sheet, 0,   162,  DEBUG_TEXT_SCALE, 0, true, "- X: %.2f", state.player.x);
@@ -1227,6 +1271,7 @@ int main(int argc, char* argv[]) {
     // Init libs
     romfsInit();
     gfxInitDefault();
+    consoleDebugInit(debugDevice_SVC);
     C3D_Init(C3D_DEFAULT_CMDBUF_SIZE * 4);
     C2D_Init(MAX_SPRITES);
     C2D_Prepare();

--- a/source/menus/gameplay.c
+++ b/source/menus/gameplay.c
@@ -1,5 +1,6 @@
 #include <3ds.h>
 #include <citro2d.h>
+#include "utils/precise_input.h"
 #include "menus/core/common_setters.h"
 #include "menus/core/ui_element.h"
 #include "menus/core/ui_screen.h"
@@ -132,6 +133,10 @@ void pause_game() {
 
 void unpause_game() {
     game_paused = false;
+    if (pi_enabled) {
+        pi_reset();
+        pi_suppress_until_release();
+    }
     if (state.death_timer <= 0 && (song_loaded || state.practice_mode)) {
         unpause_playback_mp3();
     }

--- a/source/menus/settings.c
+++ b/source/menus/settings.c
@@ -18,6 +18,7 @@
 #include "state.h"
 #include "utils/gfx.h"
 #include "utils/json_config.h"
+#include "utils/precise_input.h"
 
 static bool yes_exit = false;
 
@@ -115,11 +116,21 @@ Setting settings[] = {
         .id = "enableDebugBindings",
         .label = "Enable debug keys",
         .additionalInfo = "Enables debug key shortcuts.<p>(B + L, B + R, X)",
-        .page = PAGE_INPUT, 
+        .page = PAGE_INPUT,
 
         .defaultValue = false,
         .var = &settingsState.enableDebugBindings,
         .key = CONFIG_INPUT_PATH "enableDebugBindings"
+    },
+    {
+        .id = "preciseInput",
+        .label = "240Hz input (CBF)",
+        .additionalInfo = "Registers jumps on the exact 240Hz<p>physics tick they were pressed on.",
+        .page = PAGE_INPUT,
+
+        .defaultValue = false,
+        .var = &pi_enabled,
+        .key = CONFIG_INPUT_PATH "preciseInput"
     },
     {
         .id = "hitboxesEnabled",

--- a/source/menus/settings.h
+++ b/source/menus/settings.h
@@ -49,7 +49,7 @@ typedef struct {
     bool practiceMusicSync;
 } SettingState;
 
-extern Setting settings[22];
+extern Setting settings[23];
 extern SettingState settingsState;
 
 void settings_init();

--- a/source/menus/song_filter.c
+++ b/source/menus/song_filter.c
@@ -173,7 +173,8 @@ int song_filter_loop() {
             ui_run_func_on_tag(&screen, songs_tags[i], ui_disable_element);
         }
     }
-    strncpy(songFilterId, song_input->text, 127);
+    strncpy(song_input->text, songFilterId, sizeof(song_input->text) - 1);
+    song_input->text[sizeof(song_input->text) - 1] = '\0';
 
     UIInput touch;
     touchPosition touchPos;

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -1,9 +1,9 @@
 #include "precise_input.h"
-#include <stdio.h>
 
 #define INPUT_QUEUE_SIZE 16
 #define RING_BUFFER_ENTRIES 8
 #define RING_BUFFER_OFFSET 0x28
+#define RING_ENTRY_WORDS 4
 
 bool pi_enabled = false;
 
@@ -17,7 +17,6 @@ static u32 queue_head;
 
 static u32 last_idx;
 static u32 last_poll_tick;
-static bool first_poll = true;
 
 static bool hold_state;
 static bool suppress_hold_until_release;
@@ -26,14 +25,17 @@ static u32 frame_start;
 static u32 frame_end;
 static u32 frame_substeps;
 
+static vu32 *get_ring_buffer(void);
 static u32 sample_interval(u32 latest_tick, u32 prev_tick);
 static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval);
 static void push_event(u32 tick, bool down);
+static PreciseInputEvent peek_event(void);
+static PreciseInputEvent pop_event(void);
 static void resync_from_ring(void);
 static u32 substep_cutoff(u32 substep);
 
-static vu32 *get_ring_buffer(void) {
-    return (vu32*)((u8*)hidSharedMem + RING_BUFFER_OFFSET);
+void pi_set_jump_keys(u32 mask) {
+    jump_keys = mask;
 }
 
 void pi_reset(void) {
@@ -41,18 +43,25 @@ void pi_reset(void) {
     suppress_hold_until_release = false;
 }
 
+void pi_suppress_until_release(void) {
+    suppress_hold_until_release = true;
+}
 
-// we can read directly from the hid sysmodule (hidSharedMem) to extract 
-// the exact time a button was clicked (no syscalls, super fast!): https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0x0
+// poll to find the times that the clicks occured and schdule them for later application
 void pi_poll(void) {
     u32 now = (u32)(svcGetSystemTick());
+
+
+    // the hid sysmodule shares its button samples with every process (hidSharedMem),
+    // so we can read its ring buffer directly to find when a button was clicked: https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0x0
     u32 latest_tick = (u32)(*(vu64*)&hidSharedMem[0]);
     u32 prev_tick = (u32)(*(vu64*)&hidSharedMem[2]);
     u32 current_idx = hidSharedMem[4];
 
     u32 interval = sample_interval(latest_tick, prev_tick);
 
-    // if lag occurs we resync info from the ring buffer
+    // the lap ticks aren't initialized yet (cursor hasn't crossed slot 0), so we
+    // can't reconstruct timestamps, we resync instead
     if (interval == 0) {
         resync_from_ring();
         return;
@@ -60,9 +69,9 @@ void pi_poll(void) {
 
     u32 newest_time = latest_tick + (current_idx * interval);
 
-    u32 idx_advanced = (current_idx - last_idx) & 7;
+    u32 idx_advanced = (current_idx - last_idx) & (RING_BUFFER_ENTRIES - 1);
 
-    // calculate the number of samples elapsed since last tick
+    // calculate the number of samples elapsed since last poll
     u32 elapsed_time = now - last_poll_tick;
     u32 samples_elapsed = (elapsed_time + (interval / 2)) / interval;
 
@@ -72,27 +81,24 @@ void pi_poll(void) {
         return;
     }
 
-    // if at 30fps, then idx_advanced == 0 will look the same as moving ahead 8 slots 
-    // (making a whole lap around the ring buffer), we must differenciate between idx 
-    // not advancing and doing a whole lap by looking at the number of samples elapsed 
+    // if at 30fps, then idx_advanced == 0 will look the same as moving ahead 8 slots
+    // (making a whole lap around the ring buffer), we must differenciate between idx
+    // not advancing and doing a whole lap by looking at the number of samples elapsed
     // since the last cpu tick
     if(!idx_advanced && samples_elapsed >= (RING_BUFFER_ENTRIES / 2)){
         idx_advanced = RING_BUFFER_ENTRIES;
     }
+
     vu32 *pointer_to_ring_buffer = get_ring_buffer();
 
     for(u32 i = idx_advanced; i-- > 0;){
-        u32 slot = (current_idx - i) & 7;
-        u32 held = pointer_to_ring_buffer[(sizeof(u32) * slot)] & jump_keys;
-        u32 pressed = pointer_to_ring_buffer[1 + (sizeof(u32) * slot)] & jump_keys;
-        u32 released = pointer_to_ring_buffer[2 + (sizeof(u32) * slot)] & jump_keys;
-        bool jump = (held & jump_keys);
-        if((pressed && jump != last_sample_jump) || (released && jump != last_sample_jump)){
+        u32 slot = (current_idx - i) & (RING_BUFFER_ENTRIES - 1);
+        bool jump = (pointer_to_ring_buffer[RING_ENTRY_WORDS * slot] & jump_keys) != 0;
+        if(jump != last_sample_jump){
             u32 input_tick = reconstruct_tick(newest_time, i, interval);
-            push_event(input_tick, pressed);
+            push_event(input_tick, jump);
         }
         last_sample_jump = jump;
-        hold_state = held;
     }
     last_idx = current_idx;
     last_poll_tick = now;
@@ -104,29 +110,6 @@ void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
     frame_substeps = (substeps == 0) ? 1 : substeps;
 }
 
-static void push_event(u32 tick, bool down) {
-    if (queue_count >= INPUT_QUEUE_SIZE) {
-        return;
-    }
-    PreciseInputEvent pie;
-    pie.down = down;
-    pie.tick = tick;
-    queue[(queue_head + queue_count) % INPUT_QUEUE_SIZE] = pie;
-    queue_count++;
-}
-
-static PreciseInputEvent pop_event(void) {
-    PreciseInputEvent pie = queue[queue_head];
-    queue_head = (queue_head + 1) % INPUT_QUEUE_SIZE;
-    queue_count--;
-    return pie;
-}
-
-static PreciseInputEvent peek_event(void) {
-    PreciseInputEvent pie = queue[queue_head];
-    return pie;
-}
-
 void pi_apply_substep(u32 substep) {
     pressed_edge = false;
     u32 cutoff = substep_cutoff(substep);
@@ -136,7 +119,7 @@ void pi_apply_substep(u32 substep) {
     while(queue_count > 0){
         PreciseInputEvent pie = peek_event();
 
-        // if its the final substep before the frame ends, then we must process the clicks.
+        // stop at the first event that isnt due yet except on the final substep, which must flush everything.
         if(!final_substep && (s32)(pie.tick - cutoff) > 0){
             break;
         }
@@ -144,7 +127,7 @@ void pi_apply_substep(u32 substep) {
             break;
         }
 
-        pie = pop_event();
+        pop_event();
 
         if(pie.down){
             hold_state = true;
@@ -155,46 +138,6 @@ void pi_apply_substep(u32 substep) {
             suppress_hold_until_release = false;
         }
     }
-
-    
-}
-
-// calculates the time of each sampled interval
-static u32 sample_interval(u32 latest_tick, u32 prev_tick) {
-    return (latest_tick - prev_tick) / RING_BUFFER_ENTRIES;
-}
-
-// calculates the exact time th click occured
-static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval) {
-    // get the newest time and subtract how long ago the click happened
-    return newest_time - (samples_ago * interval);
-}
-
-static void resync_from_ring(void) {
-    queue_count = 0;
-    queue_head = 0;
-
-    last_idx = hidSharedMem[4];
-
-    vu32 *pointer_to_ring_buffer = get_ring_buffer();
-    hold_state = (pointer_to_ring_buffer[4 * last_idx] & jump_keys) != 0;   // is a jump key down NOW?
-    last_sample_jump = hold_state;
-
-    last_poll_tick = (u32)svcGetSystemTick();
-}
-
-static u32 substep_cutoff(u32 substep) {
-    u32 span = frame_end - frame_start;
-    u32 tick_per_frame = span / frame_substeps;
-    return frame_start + (tick_per_frame * (substep + 1));
-}
-
-void pi_set_jump_keys(u32 mask) {
-    jump_keys = mask;
-}
-
-void pi_suppress_until_release(void) {
-    suppress_hold_until_release = true;
 }
 
 bool pi_hold(void) {
@@ -211,4 +154,62 @@ u32 pi_event_count(void) {
 
 PreciseInputEvent pi_event_get(u32 index) {
     return queue[(queue_head + index) % INPUT_QUEUE_SIZE];
+}
+
+static vu32 *get_ring_buffer(void) {
+    return (vu32*)((u8*)hidSharedMem + RING_BUFFER_OFFSET);
+}
+
+// calculates the duration between HID samples
+static u32 sample_interval(u32 latest_tick, u32 prev_tick) {
+    return (latest_tick - prev_tick) / RING_BUFFER_ENTRIES;
+}
+
+// calculates the estimated (+/- interval) time the click occured. assumes click/release has occured
+static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval) {
+    // get the newest time and subtract how long ago the click happened
+    return newest_time - (samples_ago * interval);
+}
+
+static void push_event(u32 tick, bool down) {
+    if (queue_count >= INPUT_QUEUE_SIZE) {
+        return;
+    }
+    PreciseInputEvent pie;
+    pie.down = down;
+    pie.tick = tick;
+    queue[(queue_head + queue_count) % INPUT_QUEUE_SIZE] = pie;
+    queue_count++;
+}
+
+static PreciseInputEvent peek_event(void) {
+    return queue[queue_head];
+}
+
+static PreciseInputEvent pop_event(void) {
+    PreciseInputEvent pie = queue[queue_head];
+    queue_head = (queue_head + 1) % INPUT_QUEUE_SIZE;
+    queue_count--;
+    return pie;
+}
+
+static void resync_from_ring(void) {
+    queue_count = 0;
+    queue_head = 0;
+
+    last_idx = hidSharedMem[4];
+
+    vu32 *pointer_to_ring_buffer = get_ring_buffer();
+    hold_state = (pointer_to_ring_buffer[RING_ENTRY_WORDS * last_idx] & jump_keys) != 0;   // is a jump key down NOW?
+    last_sample_jump = hold_state;
+
+    last_poll_tick = (u32)svcGetSystemTick();
+}
+
+static u32 substep_cutoff(u32 substep) {
+    u32 span = frame_end - frame_start;
+    u32 slices_done = substep + 1;
+    u64 scaled_span = (u64)span * slices_done;
+    u32 offset_into_frame = (u32)(scaled_span / frame_substeps);
+    return frame_start + offset_into_frame;
 }

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -28,7 +28,7 @@ static u32 frame_substeps;
 static vu32 *get_ring_buffer(void);
 static u32 sample_interval(u32 latest_tick, u32 prev_tick);
 static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval);
-static void push_event(u32 tick, bool down);
+static bool push_event(u32 tick, bool down);
 static PreciseInputEvent peek_event(void);
 static PreciseInputEvent pop_event(void);
 static void resync_from_ring(void);
@@ -96,7 +96,10 @@ void pi_poll(void) {
         bool jump = (pointer_to_ring_buffer[RING_ENTRY_WORDS * slot] & jump_keys) != 0;
         if(jump != last_sample_jump){
             u32 input_tick = reconstruct_tick(newest_time, i, interval);
-            push_event(input_tick, jump);
+            if(!push_event(input_tick, jump)){
+                resync_from_ring();
+                return;
+            }
         }
         last_sample_jump = jump;
     }
@@ -171,15 +174,16 @@ static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval) {
     return newest_time - (samples_ago * interval);
 }
 
-static void push_event(u32 tick, bool down) {
+static bool push_event(u32 tick, bool down) {
     if (queue_count >= INPUT_QUEUE_SIZE) {
-        return;
+        return false;
     }
     PreciseInputEvent pie;
     pie.down = down;
     pie.tick = tick;
     queue[(queue_head + queue_count) % INPUT_QUEUE_SIZE] = pie;
     queue_count++;
+    return true;
 }
 
 static PreciseInputEvent peek_event(void) {
@@ -202,6 +206,10 @@ static void resync_from_ring(void) {
     vu32 *pointer_to_ring_buffer = get_ring_buffer();
     hold_state = (pointer_to_ring_buffer[RING_ENTRY_WORDS * last_idx] & jump_keys) != 0;   // is a jump key down NOW?
     last_sample_jump = hold_state;
+
+    if(!hold_state){
+        suppress_hold_until_release = false;
+    }
 
     last_poll_tick = (u32)svcGetSystemTick();
 }

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -4,6 +4,7 @@
 #define RING_BUFFER_ENTRIES 8
 #define RING_BUFFER_OFFSET 0x28
 #define RING_ENTRY_WORDS 4
+#define MAX_SAMPLE_INTERVAL_TICKS ((u32)(CPU_TICKS_PER_MSEC * 100))
 
 bool pi_enabled = false;
 
@@ -60,9 +61,9 @@ void pi_poll(void) {
 
     u32 interval = sample_interval(latest_tick, prev_tick);
 
-    // the lap ticks aren't initialized yet (cursor hasn't crossed slot 0), so we
-    // can't reconstruct timestamps, we resync instead
-    if (interval == 0) {
+    // the lap ticks aren't initialized yet (zero or only one stamp so far), so the
+    // interval is zero or its huge (garbage) and we can't reconstruct timestamps, we resync instead
+    if (interval == 0 || interval > MAX_SAMPLE_INTERVAL_TICKS) {
         resync_from_ring();
         return;
     }

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -78,10 +78,10 @@ void pi_poll(void) {
     u32 elapsed_time = now - last_poll_tick;
     u32 samples_elapsed = (elapsed_time + (interval / 2)) / interval;
 
-    // data was overwritted, resync
+    // data was overwritten, but insted of resyncing immediatly we go through the survivors
+    // for any recent potential inputs
     if(samples_elapsed > RING_BUFFER_ENTRIES){
-        resync_from_ring();
-        return;
+        idx_advanced = RING_BUFFER_ENTRIES;
     }
 
     // if at 30fps, then idx_advanced == 0 will look the same as moving ahead 8 slots

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -1,0 +1,128 @@
+#include "precise_input.h"
+#include <stdio.h>
+
+#define INPUT_QUEUE_SIZE 16
+#define RING_BUFFER_ENTRIES 8
+
+bool pi_enabled = false;
+
+static u32 jump_keys;
+static bool pressed_edge;
+
+static PreciseInputEvent queue[INPUT_QUEUE_SIZE];
+static u32 queue_count;
+static u32 queue_head;
+
+static u32 last_idx;
+static u32 last_poll_tick;
+static bool first_poll = true;
+
+static bool hold_state;
+static bool suppress_hold_until_release;
+
+static u32 frame_start;
+static u32 frame_end;
+static u32 frame_substeps;
+
+static u32 sample_interval(u32 latest_tick, u32 prev_tick);
+static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval);
+static bool ring_lapped(void);
+static void push_event(u32 tick, bool down);
+static void resync_from_ring(void);
+static u32 substep_cutoff(u32 substep);
+
+void pi_reset(void) {
+}
+
+
+// we can read directly from the hid sysmodule (hidSharedMem) to extract 
+// the exact time a button was clicked (no syscalls, super fast!): https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0x0
+void pi_poll(void) {
+    u32 latest_tick = (u32)(*(vu64*)&hidSharedMem[0]);
+    u32 prev_tick = (u32)(*(vu64*)&hidSharedMem[2]);
+    u32 current_idx = hidSharedMem[4];
+
+    u32 interval = sample_interval(latest_tick, prev_tick);
+    if (interval == 0) {
+        resync_from_ring();
+        return;
+    }
+
+    u32 newest_time = latest_tick + (current_idx * interval);
+
+    u32 idx_advanced = (current_idx - last_idx) & 7;
+
+    last_idx = current_idx;
+
+    u32 ring_buffer_offset = 0x28;
+    vu32 *pointer_to_ring_buffer = (vu32*)((u8*)hidSharedMem + ring_buffer_offset);
+
+    for(u32 i = idx_advanced; i-- > 0;){
+        u32 slot = (current_idx - i) & 7;
+        u32 pressed = pointer_to_ring_buffer[1 + (4 * slot)];
+        u32 released = pointer_to_ring_buffer[2 + (4 * slot)];
+        if(pressed || released){
+            u32 input_tick = reconstruct_tick(newest_time, i, interval);
+            push_event(input_tick, pressed);
+        }
+    }
+}
+
+void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
+}
+
+void pi_apply_substep(u32 substep) {
+}
+
+static u32 sample_interval(u32 latest_tick, u32 prev_tick) {
+    return (latest_tick - prev_tick) / RING_BUFFER_ENTRIES;
+}
+
+static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval) {
+    return newest_time - (samples_ago * interval);
+}
+
+static bool ring_lapped(void) {
+    return false;
+}
+
+static void push_event(u32 tick, bool down) {
+    if (queue_count >= INPUT_QUEUE_SIZE) {
+        return;
+    }
+    PreciseInputEvent pie;
+    pie.down = down;
+    pie.tick = tick;
+    queue[(queue_head + queue_count) % INPUT_QUEUE_SIZE] = pie;
+    queue_count++;
+}
+
+static void resync_from_ring(void) {
+}
+
+static u32 substep_cutoff(u32 substep) {
+    return 0;
+}
+
+void pi_set_jump_keys(u32 mask) {
+    jump_keys = mask;
+}
+
+void pi_suppress_until_release(void) {
+}
+
+bool pi_hold(void) {
+    return hold_state;
+}
+
+bool pi_pressed(void) {
+    return pressed_edge;
+}
+
+u32 pi_event_count(void) {
+    return queue_count;
+}
+
+PreciseInputEvent pi_event_get(u32 index) {
+    return queue[(queue_head + index) % INPUT_QUEUE_SIZE];
+}

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -3,11 +3,13 @@
 
 #define INPUT_QUEUE_SIZE 16
 #define RING_BUFFER_ENTRIES 8
+#define RING_BUFFER_OFFSET 0x28
 
 bool pi_enabled = false;
 
 static u32 jump_keys;
 static bool pressed_edge;
+static bool last_sample_jump;
 
 static PreciseInputEvent queue[INPUT_QUEUE_SIZE];
 static u32 queue_count;
@@ -26,10 +28,13 @@ static u32 frame_substeps;
 
 static u32 sample_interval(u32 latest_tick, u32 prev_tick);
 static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval);
-static bool ring_lapped(void);
 static void push_event(u32 tick, bool down);
 static void resync_from_ring(void);
 static u32 substep_cutoff(u32 substep);
+
+static vu32 *get_ring_buffer(void) {
+    return (vu32*)((u8*)hidSharedMem + RING_BUFFER_OFFSET);
+}
 
 void pi_reset(void) {
     resync_from_ring();
@@ -62,31 +67,32 @@ void pi_poll(void) {
     u32 samples_elapsed = (elapsed_time + (interval / 2)) / interval;
 
     // data was overwritted, resync
-    if(samples_elapsed > 8){
+    if(samples_elapsed > RING_BUFFER_ENTRIES){
         resync_from_ring();
         return;
     }
 
     // if at 30fps, then idx_advanced == 0 will look the same as moving ahead 8 slots 
-    // (making a whole lap around the ring buffer), we must differentiate between idx 
+    // (making a whole lap around the ring buffer), we must differenciate between idx 
     // not advancing and doing a whole lap by looking at the number of samples elapsed 
     // since the last cpu tick
-    if(!idx_advanced && samples_elapsed >= 4){
-        idx_advanced = 8;
+    if(!idx_advanced && samples_elapsed >= (RING_BUFFER_ENTRIES / 2)){
+        idx_advanced = RING_BUFFER_ENTRIES;
     }
-
-    u32 ring_buffer_offset = 0x28;
-    vu32 *pointer_to_ring_buffer = (vu32*)((u8*)hidSharedMem + ring_buffer_offset);
+    vu32 *pointer_to_ring_buffer = get_ring_buffer();
 
     for(u32 i = idx_advanced; i-- > 0;){
         u32 slot = (current_idx - i) & 7;
-        hold_state = pointer_to_ring_buffer[(sizeof(u32) * slot)] & KEY_A;
-        u32 pressed = pointer_to_ring_buffer[1 + (sizeof(u32) * slot)] & KEY_A;
-        u32 released = pointer_to_ring_buffer[2 + (sizeof(u32) * slot)] & KEY_A;
-        if(pressed || released){
+        u32 held = pointer_to_ring_buffer[(sizeof(u32) * slot)] & jump_keys;
+        u32 pressed = pointer_to_ring_buffer[1 + (sizeof(u32) * slot)] & jump_keys;
+        u32 released = pointer_to_ring_buffer[2 + (sizeof(u32) * slot)] & jump_keys;
+        bool jump = (held & jump_keys);
+        if((pressed && jump != last_sample_jump) || (released && jump != last_sample_jump)){
             u32 input_tick = reconstruct_tick(newest_time, i, interval);
             push_event(input_tick, pressed);
         }
+        last_sample_jump = jump;
+        hold_state = held;
     }
     last_idx = current_idx;
     last_poll_tick = now;
@@ -96,22 +102,6 @@ void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
     frame_start = frame_start_tick;
     frame_end = frame_end_tick;
     frame_substeps = (substeps == 0) ? 1 : substeps;
-}
-
-void pi_apply_substep(u32 substep) {
-
-}
-
-static u32 sample_interval(u32 latest_tick, u32 prev_tick) {
-    return (latest_tick - prev_tick) / RING_BUFFER_ENTRIES;
-}
-
-static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval) {
-    return newest_time - (samples_ago * interval);
-}
-
-static bool ring_lapped(void) {
-    return false;
 }
 
 static void push_event(u32 tick, bool down) {
@@ -125,17 +115,78 @@ static void push_event(u32 tick, bool down) {
     queue_count++;
 }
 
+static PreciseInputEvent pop_event(void) {
+    PreciseInputEvent pie = queue[queue_head];
+    queue_head = (queue_head + 1) % INPUT_QUEUE_SIZE;
+    queue_count--;
+    return pie;
+}
+
+static PreciseInputEvent peek_event(void) {
+    PreciseInputEvent pie = queue[queue_head];
+    return pie;
+}
+
+void pi_apply_substep(u32 substep) {
+    pressed_edge = false;
+    u32 cutoff = substep_cutoff(substep);
+    bool final_substep = (substep + 1 >= frame_substeps);
+    bool pressed_this_substep = false;
+
+    while(queue_count > 0){
+        PreciseInputEvent pie = peek_event();
+
+        // if its the final substep before the frame ends, then we must process the clicks.
+        if(!final_substep && (s32)(pie.tick - cutoff) > 0){
+            break;
+        }
+        if(!final_substep && pressed_this_substep){
+            break;
+        }
+
+        pie = pop_event();
+
+        if(pie.down){
+            hold_state = true;
+            pressed_edge = true;
+            pressed_this_substep = true;
+        }else{
+            hold_state =false;
+            suppress_hold_until_release = false;
+        }
+    }
+
+    
+}
+
+// calculates the time of each sampled interval
+static u32 sample_interval(u32 latest_tick, u32 prev_tick) {
+    return (latest_tick - prev_tick) / RING_BUFFER_ENTRIES;
+}
+
+// calculates the exact time th click occured
+static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval) {
+    // get the newest time and subtract how long ago the click happened
+    return newest_time - (samples_ago * interval);
+}
+
 static void resync_from_ring(void) {
     queue_count = 0;
     queue_head = 0;
 
     last_idx = hidSharedMem[4];
 
+    vu32 *pointer_to_ring_buffer = get_ring_buffer();
+    hold_state = (pointer_to_ring_buffer[4 * last_idx] & jump_keys) != 0;   // is a jump key down NOW?
+    last_sample_jump = hold_state;
+
     last_poll_tick = (u32)svcGetSystemTick();
 }
 
 static u32 substep_cutoff(u32 substep) {
-    return 0;
+    u32 span = frame_end - frame_start;
+    u32 tick_per_frame = span / frame_substeps;
+    return frame_start + (tick_per_frame * (substep + 1));
 }
 
 void pi_set_jump_keys(u32 mask) {

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -21,6 +21,7 @@ static u32 last_poll_tick;
 
 static bool hold_state;
 static bool suppress_hold_until_release;
+static bool fake_press;
 
 static u32 frame_start;
 static u32 frame_end;
@@ -42,6 +43,7 @@ void pi_set_jump_keys(u32 mask) {
 void pi_reset(void) {
     resync_from_ring();
     suppress_hold_until_release = false;
+    fake_press = false;
 }
 
 void pi_suppress_until_release(void) {
@@ -115,7 +117,8 @@ void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
 }
 
 void pi_apply_substep(u32 substep) {
-    pressed_edge = false;
+    pressed_edge = fake_press;
+    fake_press = false;
     u32 cutoff = substep_cutoff(substep);
     bool final_substep = (substep + 1 >= frame_substeps);
     bool pressed_this_substep = false;
@@ -199,6 +202,8 @@ static PreciseInputEvent pop_event(void) {
 }
 
 static void resync_from_ring(void) {
+    bool was_holding = hold_state;
+
     queue_count = 0;
     queue_head = 0;
 
@@ -210,6 +215,13 @@ static void resync_from_ring(void) {
 
     if(!hold_state){
         suppress_hold_until_release = false;
+    }
+
+    // the press edge was overwritten by the lap, but the state change survived.
+    // was can create the edge from the evidencewe have. This makes the ufo work a low frame rates
+    // because ufo's require an edge to avoid continuous flapping while holding the button.
+    if(!was_holding && hold_state && !suppress_hold_until_release){
+        fake_press = true;
     }
 
     last_poll_tick = (u32)svcGetSystemTick();

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -215,9 +215,13 @@ static void resync_from_ring(void) {
     last_poll_tick = (u32)svcGetSystemTick();
 }
 
+// calculates the tick where substeps slice of the frame window ends (events are due at or before it)
 static u32 substep_cutoff(u32 substep) {
     u32 span = frame_end - frame_start;
     u32 slices_done = substep + 1;
+
+    // on a lag spike the window can reach 0.5s with slices_done up to ~120. that
+    // product overflows if the multiplication happens in u32, so we widen to u64 first
     u64 scaled_span = (u64)span * slices_done;
     u32 offset_into_frame = (u32)(scaled_span / frame_substeps);
     return frame_start + offset_into_frame;

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -32,17 +32,22 @@ static void resync_from_ring(void);
 static u32 substep_cutoff(u32 substep);
 
 void pi_reset(void) {
+    resync_from_ring();
+    suppress_hold_until_release = false;
 }
 
 
 // we can read directly from the hid sysmodule (hidSharedMem) to extract 
 // the exact time a button was clicked (no syscalls, super fast!): https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0x0
 void pi_poll(void) {
+    u32 now = (u32)(svcGetSystemTick());
     u32 latest_tick = (u32)(*(vu64*)&hidSharedMem[0]);
     u32 prev_tick = (u32)(*(vu64*)&hidSharedMem[2]);
     u32 current_idx = hidSharedMem[4];
 
     u32 interval = sample_interval(latest_tick, prev_tick);
+
+    // if lag occurs we resync info from the ring buffer
     if (interval == 0) {
         resync_from_ring();
         return;
@@ -52,26 +57,49 @@ void pi_poll(void) {
 
     u32 idx_advanced = (current_idx - last_idx) & 7;
 
-    last_idx = current_idx;
+    // calculate the number of samples elapsed since last tick
+    u32 elapsed_time = now - last_poll_tick;
+    u32 samples_elapsed = (elapsed_time + (interval / 2)) / interval;
+
+    // data was overwritted, resync
+    if(samples_elapsed > 8){
+        resync_from_ring();
+        return;
+    }
+
+    // if at 30fps, then idx_advanced == 0 will look the same as moving ahead 8 slots 
+    // (making a whole lap around the ring buffer), we must differentiate between idx 
+    // not advancing and doing a whole lap by looking at the number of samples elapsed 
+    // since the last cpu tick
+    if(!idx_advanced && samples_elapsed >= 4){
+        idx_advanced = 8;
+    }
 
     u32 ring_buffer_offset = 0x28;
     vu32 *pointer_to_ring_buffer = (vu32*)((u8*)hidSharedMem + ring_buffer_offset);
 
     for(u32 i = idx_advanced; i-- > 0;){
         u32 slot = (current_idx - i) & 7;
-        u32 pressed = pointer_to_ring_buffer[1 + (4 * slot)];
-        u32 released = pointer_to_ring_buffer[2 + (4 * slot)];
+        hold_state = pointer_to_ring_buffer[(sizeof(u32) * slot)] & KEY_A;
+        u32 pressed = pointer_to_ring_buffer[1 + (sizeof(u32) * slot)] & KEY_A;
+        u32 released = pointer_to_ring_buffer[2 + (sizeof(u32) * slot)] & KEY_A;
         if(pressed || released){
             u32 input_tick = reconstruct_tick(newest_time, i, interval);
             push_event(input_tick, pressed);
         }
     }
+    last_idx = current_idx;
+    last_poll_tick = now;
 }
 
 void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
+    frame_start = frame_start_tick;
+    frame_end = frame_end_tick;
+    frame_substeps = (substeps == 0) ? 1 : substeps;
 }
 
 void pi_apply_substep(u32 substep) {
+
 }
 
 static u32 sample_interval(u32 latest_tick, u32 prev_tick) {
@@ -98,6 +126,12 @@ static void push_event(u32 tick, bool down) {
 }
 
 static void resync_from_ring(void) {
+    queue_count = 0;
+    queue_head = 0;
+
+    last_idx = hidSharedMem[4];
+
+    last_poll_tick = (u32)svcGetSystemTick();
 }
 
 static u32 substep_cutoff(u32 substep) {
@@ -109,10 +143,11 @@ void pi_set_jump_keys(u32 mask) {
 }
 
 void pi_suppress_until_release(void) {
+    suppress_hold_until_release = true;
 }
 
 bool pi_hold(void) {
-    return hold_state;
+    return hold_state && !suppress_hold_until_release;
 }
 
 bool pi_pressed(void) {

--- a/source/utils/precise_input.h
+++ b/source/utils/precise_input.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <3ds.h>
+#include <stdbool.h>
+
+typedef struct {
+    u32 tick;
+    bool down;
+} PreciseInputEvent;
+
+extern bool pi_enabled;
+
+void pi_reset(void);
+void pi_poll(void);
+void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps);
+void pi_apply_substep(u32 substep);
+
+void pi_set_jump_keys(u32 mask);
+void pi_suppress_until_release(void);
+bool pi_hold(void);
+bool pi_pressed(void);
+
+u32 pi_event_count(void);
+PreciseInputEvent pi_event_get(u32 index);


### PR DESCRIPTION
added precise_input.c and precise_input.h

directly reads from hidSharedMem to get the exact (limited by tick rate) time that the input was clicked/released.

added "240Hz input (CBF)" checkbox to the input settings. it is off by default.

also added fix for potentially unterminated string in the song filter id (one line fix, compiler warning was annoying)