### PR TITLE
240Hz input for touch screen inputs

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -659,7 +659,7 @@ void game_loop() {
         
         int steps = 0;
 
-        bool in_bounds = !((touchPos.px > 320 - 30 && touchPos.py < 30) || (state.practice_mode && (touchPos.px > 92 && touchPos.px < 222 && touchPos.py > 175 && touchPos.py < 222)));
+        bool in_bounds = touch_jump_filter(touchPos.px, touchPos.py);
         
         kHeldPaused &= ~kUp;
         if(!game_paused){

--- a/source/main.c
+++ b/source/main.c
@@ -526,6 +526,12 @@ void init_particles(Color p1_color, Color p2_color) {
     level_complete_effect_p2.cfg.finishColorBlue  = p2_not_white.b / 255.f;
 }
 
+static bool touch_jump_filter(u16 px, u16 py) {
+    bool on_pause_button = px > 320 - 30 && py < 30;
+    bool on_practice_ui = state.practice_mode && (px > 92 && px < 222 && py > 175 && py < 222);
+    return !(on_pause_button || on_practice_ui);
+}
+
 void game_loop() {
 #ifdef DEBUG_LEAKS
     current_generation++;
@@ -588,6 +594,7 @@ void game_loop() {
     fixed_dt = true;
 
     pi_set_jump_keys((settingsState.yJump ? KEY_Y : KEY_A) | KEY_UP);
+    pi_set_touch_filter(touch_jump_filter);
     pi_reset();
     memset(pi_substep_presses, 0, sizeof(pi_substep_presses));
 
@@ -725,8 +732,8 @@ void game_loop() {
                     if (pi_enabled) {
                         pi_apply_substep((u32)steps);
                         state.old_input = state.input;
-                        state.input.pressedJump = (pi_pressed() || touch_pressed) == true;
-                        state.input.holdJump = (pi_hold() || state.input.pressedJump || touch_held) == true;
+                        state.input.pressedJump = pi_pressed() == true;
+                        state.input.holdJump = (pi_hold() || state.input.pressedJump) == true;
                         if (pi_pressed()){
                             pi_substep_presses[steps < PI_SUBSTEP_BUCKETS ? steps : PI_SUBSTEP_BUCKETS - 1]++;
                         }

--- a/source/main.c
+++ b/source/main.c
@@ -526,10 +526,23 @@ void init_particles(Color p1_color, Color p2_color) {
     level_complete_effect_p2.cfg.finishColorBlue  = p2_not_white.b / 255.f;
 }
 
+u32 jump_key_mask(void) {
+    return (settingsState.yJump ? KEY_Y : KEY_A) | KEY_UP;
+}
+
 static bool touch_jump_filter(u16 px, u16 py) {
     bool on_pause_button = px > 320 - 30 && py < 30;
     bool on_practice_ui = state.practice_mode && (px > 92 && px < 222 && py > 175 && py < 222);
     return !(on_pause_button || on_practice_ui);
+}
+
+void sync_precise_input(bool suppress_held) {
+    pi_set_jump_keys(jump_key_mask());
+    pi_set_touch_filter(touch_jump_filter);
+    pi_reset();
+    if (suppress_held) {
+        pi_suppress_until_release();
+    }
 }
 
 void game_loop() {
@@ -593,9 +606,7 @@ void game_loop() {
     exiting_level = false;
     fixed_dt = true;
 
-    pi_set_jump_keys((settingsState.yJump ? KEY_Y : KEY_A) | KEY_UP);
-    pi_set_touch_filter(touch_jump_filter);
-    pi_reset();
+    sync_precise_input(false);
     memset(pi_substep_presses, 0, sizeof(pi_substep_presses));
 
     u64 lastTime = svcGetSystemTick();
@@ -668,8 +679,8 @@ void game_loop() {
         
         global_volume = get_volume_slider();
 
-        bool buttonPressed = (settingsState.yJump ? (kDown & KEY_Y) : (kDown & KEY_A)) || (kDown & KEY_UP);
-        bool buttonHeld = (settingsState.yJump ? (kHeld & KEY_Y) : (kHeld & KEY_A)) || (kHeld & KEY_UP);
+        bool buttonPressed = (kDown & jump_key_mask()) != 0;
+        bool buttonHeld = (kHeld & jump_key_mask()) != 0;
 
         bool touch_pressed = in_bounds && (kDown & KEY_TOUCH);
         bool touch_held = in_bounds && (kHeld & KEY_TOUCH);
@@ -861,7 +872,7 @@ void game_loop() {
                     }
 
                     if (song_loaded) unpause_playback_mp3();
-                    pi_reset();
+                    sync_precise_input(false);
                     fixed_dt = true;
                     state.dead = false;
                     state.hitbox_display = 0;

--- a/source/main.c
+++ b/source/main.c
@@ -733,6 +733,11 @@ void game_loop() {
                 }
                 accumulator += physics_delta;
 
+                // in case of merge conflicts: this needs to stay after the accumulator deposit above.
+                // planned is how many substeps this frame is about to run, so if we calculate it
+                // before the deposit, the accumulator only has the leftover from last frame and
+                // planned will always be 1, making every input land on a single substep like normal
+                // frame latching (no error, it will just silently get less precise)
                 u32 planned = (u32)(accumulator / STEPS_DT_UNMOD);
                 pi_begin_frame((u32)frame_window_start, (u32)now, planned ? planned : 1);
 

--- a/source/main.h
+++ b/source/main.h
@@ -129,4 +129,7 @@ float get_volume_slider();
 
 int output_log(const char *fmt, ...);
 
+u32 jump_key_mask(void);
+void sync_precise_input(bool suppress_held);
+
 bool is_citra();

--- a/source/menus/gameplay.c
+++ b/source/menus/gameplay.c
@@ -134,6 +134,7 @@ void pause_game() {
 void unpause_game() {
     game_paused = false;
     if (pi_enabled) {
+        pi_set_jump_keys((settingsState.yJump ? KEY_Y : KEY_A) | KEY_UP);
         pi_reset();
         pi_suppress_until_release();
     }

--- a/source/menus/gameplay.c
+++ b/source/menus/gameplay.c
@@ -134,9 +134,7 @@ void pause_game() {
 void unpause_game() {
     game_paused = false;
     if (pi_enabled) {
-        pi_set_jump_keys((settingsState.yJump ? KEY_Y : KEY_A) | KEY_UP);
-        pi_reset();
-        pi_suppress_until_release();
+        sync_precise_input(true);
     }
     if (state.death_timer <= 0 && (song_loaded || state.practice_mode)) {
         unpause_playback_mp3();

--- a/source/menus/settings.c
+++ b/source/menus/settings.c
@@ -125,7 +125,7 @@ Setting settings[] = {
     {
         .id = "preciseInput",
         .label = "240Hz input (CBF)",
-        .additionalInfo = "Registers jumps on the exact 240Hz<p>physics tick they were pressed on.",
+        .additionalInfo = "Registers jumps on the exact 240Hz<p>physics tick they were pressed on.<p>Precision is reduced below 30fps.",
         .page = PAGE_INPUT,
 
         .defaultValue = false,

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -2,7 +2,7 @@
 
 #define INPUT_QUEUE_SIZE 16
 #define RING_BUFFER_ENTRIES 8
-#define RING_ENTRY_WORDS 4
+#define PAD_RING_ENTRY_WORDS 4
 
 #define TOUCH_RING_ENTRY_WORDS 2
 #define MAX_SAMPLE_INTERVAL_TICKS ((u32)(CPU_TICKS_PER_MSEC * 100))
@@ -68,6 +68,10 @@ static void apply_source(PreciseSource *src, u32 substep);
 static void resync_from_ring(PreciseSource *src);
 static u32 substep_cutoff(u32 substep);
 
+void pi_set_touch_filter(bool (*filter)(u16 px, u16 py)){
+    touch_filter = filter;
+}
+
 void pi_set_jump_keys(u32 mask) {
     jump_keys = mask;
 }
@@ -113,17 +117,25 @@ bool pi_pressed(void) {
     return pad.pressed_edge || touch.pressed_edge;
 }
 
-u32 pi_event_count(void) {
+u32 pi_pad_event_count(void) {
     return pad.queue_count;
 }
 
-PreciseInputEvent pi_event_get(u32 index) {
+u32 pi_touch_event_count(void) {
+    return touch.queue_count;
+}
+
+PreciseInputEvent pi_pad_event_get(u32 index) {
     return pad.queue[(pad.queue_head + index) % INPUT_QUEUE_SIZE];
+}
+
+PreciseInputEvent pi_touch_event_get(u32 index) {
+    return touch.queue[(touch.queue_head + index) % INPUT_QUEUE_SIZE];
 }
 
 static bool pad_sample_jump(u32 slot) {
     vu32 *pointer_to_ring_buffer = get_ring_buffer(&pad);
-    return (pointer_to_ring_buffer[RING_ENTRY_WORDS * slot] & jump_keys) != 0;
+    return (pointer_to_ring_buffer[PAD_RING_ENTRY_WORDS * slot] & jump_keys) != 0;
 }
 
 static bool touch_sample_jump(u32 slot) {

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -3,6 +3,7 @@
 #define INPUT_QUEUE_SIZE 16
 #define RING_BUFFER_ENTRIES 8
 #define RING_ENTRY_WORDS 4
+
 #define TOUCH_RING_ENTRY_WORDS 2
 #define MAX_SAMPLE_INTERVAL_TICKS ((u32)(CPU_TICKS_PER_MSEC * 100))
 
@@ -73,17 +74,22 @@ void pi_set_jump_keys(u32 mask) {
 
 void pi_reset(void) {
     resync_from_ring(&pad);
+    resync_from_ring(&touch);
     pad.suppress_hold_until_release = false;
     pad.fake_press = false;
+    touch.suppress_hold_until_release = false;
+    touch.fake_press = false;
 }
 
 void pi_suppress_until_release(void) {
     pad.suppress_hold_until_release = true;
+    touch.suppress_hold_until_release = true;
 }
 
 // poll to find the times that the clicks occured and schdule them for later application
 void pi_poll(void) {
     poll_source(&pad);
+    poll_source(&touch);
 }
 
 void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
@@ -94,14 +100,17 @@ void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
 
 void pi_apply_substep(u32 substep) {
     apply_source(&pad, substep);
+    apply_source(&touch, substep);
 }
 
 bool pi_hold(void) {
-    return pad.hold_state && !pad.suppress_hold_until_release;
+    bool pad_hold = pad.hold_state && !pad.suppress_hold_until_release;
+    bool touch_hold = touch.hold_state && !touch.suppress_hold_until_release;
+    return pad_hold || touch_hold;
 }
 
 bool pi_pressed(void) {
-    return pad.pressed_edge;
+    return pad.pressed_edge || touch.pressed_edge;
 }
 
 u32 pi_event_count(void) {
@@ -120,7 +129,7 @@ static bool pad_sample_jump(u32 slot) {
 static bool touch_sample_jump(u32 slot) {
     vu32 *pointer_to_ring_buffer = get_ring_buffer(&touch);
     u32 position = pointer_to_ring_buffer[TOUCH_RING_ENTRY_WORDS * slot];
-    u32 valid = pointer_to_ring_buffer[TOUCH_RING_ENTRY_WORDS * slot + 1];
+    u32 valid = pointer_to_ring_buffer[(TOUCH_RING_ENTRY_WORDS * slot) + 1];
 
     if (!valid) {
         return false;

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -136,13 +136,14 @@ void pi_apply_substep(u32 substep) {
 
         pop_event();
 
+        suppress_hold_until_release = false;
+
         if(pie.down){
             hold_state = true;
             pressed_edge = true;
             pressed_this_substep = true;
         }else{
             hold_state =false;
-            suppress_hold_until_release = false;
         }
     }
 }

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -9,31 +9,47 @@
 bool pi_enabled = false;
 
 static u32 jump_keys;
-static bool pressed_edge;
-static bool last_sample_jump;
-
-static PreciseInputEvent queue[INPUT_QUEUE_SIZE];
-static u32 queue_count;
-static u32 queue_head;
-
-static u32 last_idx;
-static u32 last_poll_tick;
-
-static bool hold_state;
-static bool suppress_hold_until_release;
-static bool fake_press;
 
 static u32 frame_start;
 static u32 frame_end;
 static u32 frame_substeps;
 
+typedef struct {
+    u32 tick_word;
+    u32 idx_word;
+    bool (*sample_jump)(u32 slot);
+
+    PreciseInputEvent queue[INPUT_QUEUE_SIZE];
+    u32 queue_count;
+    u32 queue_head;
+
+    u32 last_idx;
+    u32 last_poll_tick;
+    bool last_sample_jump;
+
+    bool hold_state;
+    bool suppress_hold_until_release;
+    bool fake_press;
+    bool pressed_edge;
+} PreciseSource;
+
+static bool pad_sample_jump(u32 slot);
+
+static PreciseSource pad = {
+    .tick_word = 0,
+    .idx_word = 4,
+    .sample_jump = pad_sample_jump,
+};
+
 static vu32 *get_ring_buffer(void);
 static u32 sample_interval(u32 latest_tick, u32 prev_tick);
 static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval);
-static bool push_event(u32 tick, bool down);
-static PreciseInputEvent peek_event(void);
-static PreciseInputEvent pop_event(void);
-static void resync_from_ring(void);
+static bool push_event(PreciseSource *src, u32 tick, bool down);
+static PreciseInputEvent peek_event(PreciseSource *src);
+static PreciseInputEvent pop_event(PreciseSource *src);
+static void poll_source(PreciseSource *src);
+static void apply_source(PreciseSource *src, u32 substep);
+static void resync_from_ring(PreciseSource *src);
 static u32 substep_cutoff(u32 substep);
 
 void pi_set_jump_keys(u32 mask) {
@@ -41,73 +57,18 @@ void pi_set_jump_keys(u32 mask) {
 }
 
 void pi_reset(void) {
-    resync_from_ring();
-    suppress_hold_until_release = false;
-    fake_press = false;
+    resync_from_ring(&pad);
+    pad.suppress_hold_until_release = false;
+    pad.fake_press = false;
 }
 
 void pi_suppress_until_release(void) {
-    suppress_hold_until_release = true;
+    pad.suppress_hold_until_release = true;
 }
 
 // poll to find the times that the clicks occured and schdule them for later application
 void pi_poll(void) {
-    u32 now = (u32)(svcGetSystemTick());
-
-
-    // the hid sysmodule shares its button samples with every process (hidSharedMem),
-    // so we can read its ring buffer directly to find when a button was clicked: https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0x0
-    u32 latest_tick = (u32)(*(vu64*)&hidSharedMem[0]);
-    u32 prev_tick = (u32)(*(vu64*)&hidSharedMem[2]);
-    u32 current_idx = hidSharedMem[4];
-
-    u32 interval = sample_interval(latest_tick, prev_tick);
-
-    // the lap ticks aren't initialized yet (zero or only one stamp so far), so the
-    // interval is zero or its huge (garbage) and we can't reconstruct timestamps, we resync instead
-    if (interval == 0 || interval > MAX_SAMPLE_INTERVAL_TICKS) {
-        resync_from_ring();
-        return;
-    }
-
-    u32 newest_time = latest_tick + (current_idx * interval);
-
-    u32 idx_advanced = (current_idx - last_idx) & (RING_BUFFER_ENTRIES - 1);
-
-    // calculate the number of samples elapsed since last poll
-    u32 elapsed_time = now - last_poll_tick;
-    u32 samples_elapsed = (elapsed_time + (interval / 2)) / interval;
-
-    // data was overwritten, but insted of resyncing immediatly we go through the survivors
-    // for any recent potential inputs
-    if(samples_elapsed > RING_BUFFER_ENTRIES){
-        idx_advanced = RING_BUFFER_ENTRIES;
-    }
-
-    // if at 30fps, then idx_advanced == 0 will look the same as moving ahead 8 slots
-    // (making a whole lap around the ring buffer), we must differenciate between idx
-    // not advancing and doing a whole lap by looking at the number of samples elapsed
-    // since the last cpu tick
-    if(!idx_advanced && samples_elapsed >= (RING_BUFFER_ENTRIES / 2)){
-        idx_advanced = RING_BUFFER_ENTRIES;
-    }
-
-    vu32 *pointer_to_ring_buffer = get_ring_buffer();
-
-    for(u32 i = idx_advanced; i-- > 0;){
-        u32 slot = (current_idx - i) & (RING_BUFFER_ENTRIES - 1);
-        bool jump = (pointer_to_ring_buffer[RING_ENTRY_WORDS * slot] & jump_keys) != 0;
-        if(jump != last_sample_jump){
-            u32 input_tick = reconstruct_tick(newest_time, i, interval);
-            if(!push_event(input_tick, jump)){
-                resync_from_ring();
-                return;
-            }
-        }
-        last_sample_jump = jump;
-    }
-    last_idx = current_idx;
-    last_poll_tick = now;
+    poll_source(&pad);
 }
 
 void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
@@ -117,51 +78,28 @@ void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps) {
 }
 
 void pi_apply_substep(u32 substep) {
-    pressed_edge = fake_press;
-    fake_press = false;
-    u32 cutoff = substep_cutoff(substep);
-    bool final_substep = (substep + 1 >= frame_substeps);
-    bool pressed_this_substep = false;
-
-    while(queue_count > 0){
-        PreciseInputEvent pie = peek_event();
-
-        // stop at the first event that isnt due yet except on the final substep, which must flush everything.
-        if(!final_substep && (s32)(pie.tick - cutoff) > 0){
-            break;
-        }
-        if(!final_substep && pressed_this_substep){
-            break;
-        }
-
-        pop_event();
-
-        suppress_hold_until_release = false;
-
-        if(pie.down){
-            hold_state = true;
-            pressed_edge = true;
-            pressed_this_substep = true;
-        }else{
-            hold_state =false;
-        }
-    }
+    apply_source(&pad, substep);
 }
 
 bool pi_hold(void) {
-    return hold_state && !suppress_hold_until_release;
+    return pad.hold_state && !pad.suppress_hold_until_release;
 }
 
 bool pi_pressed(void) {
-    return pressed_edge;
+    return pad.pressed_edge;
 }
 
 u32 pi_event_count(void) {
-    return queue_count;
+    return pad.queue_count;
 }
 
 PreciseInputEvent pi_event_get(u32 index) {
-    return queue[(queue_head + index) % INPUT_QUEUE_SIZE];
+    return pad.queue[(pad.queue_head + index) % INPUT_QUEUE_SIZE];
+}
+
+static bool pad_sample_jump(u32 slot) {
+    vu32 *pointer_to_ring_buffer = get_ring_buffer();
+    return (pointer_to_ring_buffer[RING_ENTRY_WORDS * slot] & jump_keys) != 0;
 }
 
 static vu32 *get_ring_buffer(void) {
@@ -179,53 +117,141 @@ static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval) {
     return newest_time - (samples_ago * interval);
 }
 
-static bool push_event(u32 tick, bool down) {
-    if (queue_count >= INPUT_QUEUE_SIZE) {
+static bool push_event(PreciseSource *src, u32 tick, bool down) {
+    if (src->queue_count >= INPUT_QUEUE_SIZE) {
         return false;
     }
     PreciseInputEvent pie;
     pie.down = down;
     pie.tick = tick;
-    queue[(queue_head + queue_count) % INPUT_QUEUE_SIZE] = pie;
-    queue_count++;
+    src->queue[(src->queue_head + src->queue_count) % INPUT_QUEUE_SIZE] = pie;
+    src->queue_count++;
     return true;
 }
 
-static PreciseInputEvent peek_event(void) {
-    return queue[queue_head];
+static PreciseInputEvent peek_event(PreciseSource *src) {
+    return src->queue[src->queue_head];
 }
 
-static PreciseInputEvent pop_event(void) {
-    PreciseInputEvent pie = queue[queue_head];
-    queue_head = (queue_head + 1) % INPUT_QUEUE_SIZE;
-    queue_count--;
+static PreciseInputEvent pop_event(PreciseSource *src) {
+    PreciseInputEvent pie = src->queue[src->queue_head];
+    src->queue_head = (src->queue_head + 1) % INPUT_QUEUE_SIZE;
+    src->queue_count--;
     return pie;
 }
 
-static void resync_from_ring(void) {
-    bool was_holding = hold_state;
+static void poll_source(PreciseSource *src) {
+    u32 now = (u32)(svcGetSystemTick());
 
-    queue_count = 0;
-    queue_head = 0;
 
-    last_idx = hidSharedMem[4];
+    // the hid sysmodule shares its button samples with every process (hidSharedMem),
+    // so we can read its ring buffer directly to find when a button was clicked: https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0x0
+    u32 latest_tick = (u32)(*(vu64*)&hidSharedMem[src->tick_word]);
+    u32 prev_tick = (u32)(*(vu64*)&hidSharedMem[src->tick_word + 2]);
+    u32 current_idx = hidSharedMem[src->idx_word];
 
-    vu32 *pointer_to_ring_buffer = get_ring_buffer();
-    hold_state = (pointer_to_ring_buffer[RING_ENTRY_WORDS * last_idx] & jump_keys) != 0;   // is a jump key down NOW?
-    last_sample_jump = hold_state;
+    u32 interval = sample_interval(latest_tick, prev_tick);
 
-    if(!hold_state){
-        suppress_hold_until_release = false;
+    // the lap ticks aren't initialized yet (zero or only one stamp so far), so the
+    // interval is zero or its huge (garbage) and we can't reconstruct timestamps, we resync instead
+    if (interval == 0 || interval > MAX_SAMPLE_INTERVAL_TICKS) {
+        resync_from_ring(src);
+        return;
+    }
+
+    u32 newest_time = latest_tick + (current_idx * interval);
+
+    u32 idx_advanced = (current_idx - src->last_idx) & (RING_BUFFER_ENTRIES - 1);
+
+    // calculate the number of samples elapsed since last poll
+    u32 elapsed_time = now - src->last_poll_tick;
+    u32 samples_elapsed = (elapsed_time + (interval / 2)) / interval;
+
+    // data was overwritten, but insted of resyncing immediatly we go through the survivors
+    // for any recent potential inputs
+    if(samples_elapsed > RING_BUFFER_ENTRIES){
+        idx_advanced = RING_BUFFER_ENTRIES;
+    }
+
+    // if at 30fps, then idx_advanced == 0 will look the same as moving ahead 8 slots
+    // (making a whole lap around the ring buffer), we must differenciate between idx
+    // not advancing and doing a whole lap by looking at the number of samples elapsed
+    // since the last cpu tick
+    if(!idx_advanced && samples_elapsed >= (RING_BUFFER_ENTRIES / 2)){
+        idx_advanced = RING_BUFFER_ENTRIES;
+    }
+
+    for(u32 i = idx_advanced; i-- > 0;){
+        u32 slot = (current_idx - i) & (RING_BUFFER_ENTRIES - 1);
+        bool jump = src->sample_jump(slot);
+        if(jump != src->last_sample_jump){
+            u32 input_tick = reconstruct_tick(newest_time, i, interval);
+            if(!push_event(src, input_tick, jump)){
+                resync_from_ring(src);
+                return;
+            }
+        }
+        src->last_sample_jump = jump;
+    }
+    src->last_idx = current_idx;
+    src->last_poll_tick = now;
+}
+
+static void apply_source(PreciseSource *src, u32 substep) {
+    src->pressed_edge = src->fake_press;
+    src->fake_press = false;
+    u32 cutoff = substep_cutoff(substep);
+    bool final_substep = (substep + 1 >= frame_substeps);
+    bool pressed_this_substep = false;
+
+    while(src->queue_count > 0){
+        PreciseInputEvent pie = peek_event(src);
+
+        // stop at the first event that isnt due yet except on the final substep, which must flush everything.
+        if(!final_substep && (s32)(pie.tick - cutoff) > 0){
+            break;
+        }
+        if(!final_substep && pressed_this_substep){
+            break;
+        }
+
+        pop_event(src);
+
+        src->suppress_hold_until_release = false;
+
+        if(pie.down){
+            src->hold_state = true;
+            src->pressed_edge = true;
+            pressed_this_substep = true;
+        }else{
+            src->hold_state = false;
+        }
+    }
+}
+
+static void resync_from_ring(PreciseSource *src) {
+    bool was_holding = src->hold_state;
+
+    src->queue_count = 0;
+    src->queue_head = 0;
+
+    src->last_idx = hidSharedMem[src->idx_word];
+
+    src->hold_state = src->sample_jump(src->last_idx);   // is a jump key down NOW?
+    src->last_sample_jump = src->hold_state;
+
+    if(!src->hold_state){
+        src->suppress_hold_until_release = false;
     }
 
     // the press edge was overwritten by the lap, but the state change survived.
     // was can create the edge from the evidencewe have. This makes the ufo work a low frame rates
     // because ufo's require an edge to avoid continuous flapping while holding the button.
-    if(!was_holding && hold_state && !suppress_hold_until_release){
-        fake_press = true;
+    if(!was_holding && src->hold_state && !src->suppress_hold_until_release){
+        src->fake_press = true;
     }
 
-    last_poll_tick = (u32)svcGetSystemTick();
+    src->last_poll_tick = (u32)svcGetSystemTick();
 }
 
 // calculates the tick where substeps slice of the frame window ends (events are due at or before it)

--- a/source/utils/precise_input.c
+++ b/source/utils/precise_input.c
@@ -2,13 +2,14 @@
 
 #define INPUT_QUEUE_SIZE 16
 #define RING_BUFFER_ENTRIES 8
-#define RING_BUFFER_OFFSET 0x28
 #define RING_ENTRY_WORDS 4
+#define TOUCH_RING_ENTRY_WORDS 2
 #define MAX_SAMPLE_INTERVAL_TICKS ((u32)(CPU_TICKS_PER_MSEC * 100))
 
 bool pi_enabled = false;
 
 static u32 jump_keys;
+static bool (*touch_filter)(u16 px, u16 py);
 
 static u32 frame_start;
 static u32 frame_end;
@@ -17,6 +18,9 @@ static u32 frame_substeps;
 typedef struct {
     u32 tick_word;
     u32 idx_word;
+
+    u32 ring_buffer_offset;
+
     bool (*sample_jump)(u32 slot);
 
     PreciseInputEvent queue[INPUT_QUEUE_SIZE];
@@ -34,14 +38,25 @@ typedef struct {
 } PreciseSource;
 
 static bool pad_sample_jump(u32 slot);
+static bool touch_sample_jump(u32 slot);
 
+// https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0x0
 static PreciseSource pad = {
     .tick_word = 0,
     .idx_word = 4,
+    .ring_buffer_offset = 0x28,
     .sample_jump = pad_sample_jump,
 };
 
-static vu32 *get_ring_buffer(void);
+// https://www.3dbrew.org/wiki/HID_Shared_Memory#Offset_0xA8
+static PreciseSource touch = {
+    .tick_word = 42,
+    .idx_word = 46,
+    .ring_buffer_offset = 0xA8 + 0x20,
+    .sample_jump = touch_sample_jump,
+};
+
+static vu32 *get_ring_buffer(PreciseSource* src);
 static u32 sample_interval(u32 latest_tick, u32 prev_tick);
 static u32 reconstruct_tick(u32 newest_time, u32 samples_ago, u32 interval);
 static bool push_event(PreciseSource *src, u32 tick, bool down);
@@ -98,12 +113,30 @@ PreciseInputEvent pi_event_get(u32 index) {
 }
 
 static bool pad_sample_jump(u32 slot) {
-    vu32 *pointer_to_ring_buffer = get_ring_buffer();
+    vu32 *pointer_to_ring_buffer = get_ring_buffer(&pad);
     return (pointer_to_ring_buffer[RING_ENTRY_WORDS * slot] & jump_keys) != 0;
 }
 
-static vu32 *get_ring_buffer(void) {
-    return (vu32*)((u8*)hidSharedMem + RING_BUFFER_OFFSET);
+static bool touch_sample_jump(u32 slot) {
+    vu32 *pointer_to_ring_buffer = get_ring_buffer(&touch);
+    u32 position = pointer_to_ring_buffer[TOUCH_RING_ENTRY_WORDS * slot];
+    u32 valid = pointer_to_ring_buffer[TOUCH_RING_ENTRY_WORDS * slot + 1];
+
+    if (!valid) {
+        return false;
+    }
+
+    if (touch_filter) {
+        u16 px = (u16)(position & 0xFFFF);
+        u16 py = (u16)(position >> 16);
+        return touch_filter(px, py);
+    }
+
+    return true;
+}
+
+static vu32 *get_ring_buffer(PreciseSource* src) {
+    return (vu32*)((u8*)hidSharedMem + src->ring_buffer_offset);
 }
 
 // calculates the duration between HID samples

--- a/source/utils/precise_input.h
+++ b/source/utils/precise_input.h
@@ -20,7 +20,7 @@ void pi_suppress_until_release(void);
 bool pi_hold(void);
 bool pi_pressed(void);
 
-u32 pi_event_count(void);
-PreciseInputEvent pi_event_get(u32 index);
+u32 pi_pad_event_count(void);
+PreciseInputEvent pi_pad_event_get(u32 index);
 u32 pi_touch_event_count(void);
 PreciseInputEvent pi_touch_event_get(u32 index);

--- a/source/utils/precise_input.h
+++ b/source/utils/precise_input.h
@@ -15,9 +15,12 @@ void pi_begin_frame(u32 frame_start_tick, u32 frame_end_tick, u32 substeps);
 void pi_apply_substep(u32 substep);
 
 void pi_set_jump_keys(u32 mask);
+void pi_set_touch_filter(bool (*filter)(u16 px, u16 py));
 void pi_suppress_until_release(void);
 bool pi_hold(void);
 bool pi_pressed(void);
 
 u32 pi_event_count(void);
 PreciseInputEvent pi_event_get(u32 index);
+u32 pi_touch_event_count(void);
+PreciseInputEvent pi_touch_event_get(u32 index);


### PR DESCRIPTION
not having this bugged me a bit so here it is

works basically the same way as regular button inputs, just added the touch screen offsets to the code so that it works with touch screen as well.

I also added some abstractions for the jump keys and the touch dead zones (jump_key_mask and touch_jump_filter) so that they each live in one function instead of being copy pasted around. so if anyone adds ui to the bottom screen later or change the click inputs for some reason, they only need to update one function for each and it will work for both normal inputs and cbf. there is also a sync_precise_input function now that handles everything that cbf needs to happen when gameplay resumes (entering a level, respawn, unpause).