### PR TITLE
Move level object transforms to Citro3D

### DIFF
--- a/source/graphics.c
+++ b/source/graphics.c
@@ -16,6 +16,7 @@
 #include "player/collision.h"
 
 #include "utils/gfx.h"
+#include "object_renderer.h"
 
 #include "particles/object_particles.h"
 #include "particles/circles.h"
@@ -159,17 +160,23 @@ void cache_all_sprites() {
         // Children
         sprite_templates[id].child_count = obj->child_count;
         if (obj->child_count > 0) {
-            sprite_templates[id].child_templates = malloc(sizeof(C2D_Sprite) * obj->child_count);
+            sprite_templates[id].child_templates = malloc(sizeof(ChildSpriteTemplate) * obj->child_count);
             for (int i = 0; i < obj->child_count; i++) {
                 const ChildSprite* c = &obj->children[i];
+
+                float child_rotation = C3D_AngleFromDegrees(c->rot);
+                sprite_templates[id].child_templates[i].rotation_sin = sinf(child_rotation);
+                sprite_templates[id].child_templates[i].rotation_cos = cosf(child_rotation);
+
                 if (c->texture < 0) continue;
 
                 int c_tex;
                 C2D_SpriteSheet *c_sheet = get_sprite_sheet(c->texture, &c_tex);
 
-                C2D_SpriteFromSheet(&sprite_templates[id].child_templates[i], *c_sheet, c_tex);
-                C3D_TexSetFilter(sprite_templates[id].child_templates[i].image.tex, GPU_LINEAR, GPU_LINEAR);
-                C2D_SpriteSetCenter(&sprite_templates[id].child_templates[i], 0.5f, 0.5f);
+                C2D_Sprite *child_template = &sprite_templates[id].child_templates[i].sprite;
+                C2D_SpriteFromSheet(child_template, *c_sheet, c_tex);
+                C3D_TexSetFilter(child_template->image.tex, GPU_LINEAR, GPU_LINEAR);
+                C2D_SpriteSetCenter(child_template, 0.5f, 0.5f);
             }
         } else {
             sprite_templates[id].child_templates = NULL;
@@ -513,6 +520,30 @@ float get_object_pulse(float amplitude, int id, int layer) {
     return 1.0f;
 }
 
+// Keep the compact per-object transform in the render list. The raw Citro3D
+// object renderer expands it in its vertex shader instead of rotating all four
+// corners on the CPU through Citro2D.
+static inline void set_sprite_render_data(
+    SpriteObject *sprite,
+    const C2D_Image image,
+    float x,
+    float y,
+    float scale_x,
+    float scale_y,
+    float rotation_sin,
+    float rotation_cos
+) {
+    sprite->image = image;
+    sprite->x = x;
+    sprite->y = y;
+    sprite->half_width = fabsf(scale_x * image.subtex->width) * 0.5f;
+    sprite->half_height = fabsf(scale_y * image.subtex->height) * 0.5f;
+    sprite->rotation_sin = rotation_sin;
+    sprite->rotation_cos = rotation_cos;
+    sprite->flip_x = scale_x < 0.f;
+    sprite->flip_y = scale_y < 0.f;
+}
+
 void spawn_object_at(
     int obj_game,
     int id,
@@ -556,26 +587,21 @@ void spawn_object_at(
         float p_y = y + rot_y * scale;
 
         int random_layer = get_obj_random_layer(obj_game, id);
+        C2D_Image image;
         if (random_layer < 0) {
-            vo->spr = sprite_templates[id].parent_template;
+            image = sprite_templates[id].parent_template.image;
         } else {
             int rel_index;
             C2D_SpriteSheet *sheet = get_sprite_sheet(random_layer, &rel_index);
-            C2D_Sprite rnd = { 0 };
-            vo->spr = rnd;
-            C2D_SpriteFromSheet(&vo->spr, *sheet, rel_index);
-            C2D_SpriteSetCenter(&vo->spr, 0.5f, 0.5f);
+            image = C2D_SpriteSheetGetImage(*sheet, rel_index);
         }
 
         float pulse_scale = get_object_pulse(amplitude, id, 0);
 
-        C2D_SpriteSetPos(&vo->spr, p_x, p_y);
-        C2D_SpriteSetScale(&vo->spr, sx * pulse_scale, sy * pulse_scale);
-        C2D_SpriteSetRotation(&vo->spr, rad);
+        set_sprite_render_data(vo, image, p_x, p_y, sx * pulse_scale, sy * pulse_scale, sin_r, cos_r);
 
         vo->obj = obj_game;
         vo->layer = 0;
-        vo->col_type = obj->color_type;
         vo->opacity = obj->opacity;
         vo->col_channel = get_color_channel(obj->color_type, obj_game, obj);
         viewable_objects_ptr[sprite_count] = vo;
@@ -588,17 +614,13 @@ void spawn_object_at(
 
         SpriteObject *vo = &viewable_objects[sprite_count];
 
-        vo->spr = sprite_templates[id].glow_template;
-
         float pulse_scale = get_object_pulse(amplitude, id, 1);
 
-        C2D_SpriteSetPos(&vo->spr, x, y);
-        C2D_SpriteSetScale(&vo->spr, sx * pulse_scale, sy * pulse_scale);
-        C2D_SpriteSetRotation(&vo->spr, rad);
+        set_sprite_render_data(vo, sprite_templates[id].glow_template.image,
+            x, y, sx * pulse_scale, sy * pulse_scale, sin_r, cos_r);
 
         vo->obj = obj_game;
         vo->layer = 1;
-        vo->col_type = COLOR_TYPE_BASE;
         vo->opacity = obj->opacity;
         vo->col_channel = get_glow_channel(obj_game);
         viewable_objects_ptr[sprite_count] = vo;
@@ -627,23 +649,24 @@ void spawn_object_at(
             int c_flip_x_mult = (c->flip_x ? -1 : 1);
             int c_flip_y_mult = (c->flip_y ? -1 : 1);
 
-            vo->spr = sprite_templates[id].child_templates[i]; 
-
             float pulse_scale = get_object_pulse(amplitude, id, i + 2);
-
-            C2D_SpriteSetPos(&vo->spr, c_x, c_y);
+            const ChildSpriteTemplate *child_template = &sprite_templates[id].child_templates[i];
             if (id < 15 || id > 17) {
-                C2D_SpriteSetScale(&vo->spr, c->scale_x * c_flip_x_mult * sx * pulse_scale,
-                                          c->scale_y * c_flip_y_mult * sy * pulse_scale);
-                C2D_SpriteSetRotation(&vo->spr, C3D_AngleFromDegrees(c->rot) + rad);
+                float child_sin = sin_r * child_template->rotation_cos + cos_r * child_template->rotation_sin;
+                float child_cos = cos_r * child_template->rotation_cos - sin_r * child_template->rotation_sin;
+                set_sprite_render_data(vo, child_template->sprite.image, c_x, c_y,
+                    c->scale_x * c_flip_x_mult * sx * pulse_scale,
+                    c->scale_y * c_flip_y_mult * sy * pulse_scale,
+                    child_sin, child_cos);
             } else {
-                C2D_SpriteSetScale(&vo->spr, fabsf(c->scale_x * c_flip_x_mult * sx * pulse_scale),
-                                          fabsf(c->scale_y * c_flip_y_mult * sy * pulse_scale));
+                set_sprite_render_data(vo, child_template->sprite.image, c_x, c_y,
+                    fabsf(c->scale_x * c_flip_x_mult * sx * pulse_scale),
+                    fabsf(c->scale_y * c_flip_y_mult * sy * pulse_scale),
+                    0.f, 1.f);
             }
 
             vo->obj = obj_game;
             vo->layer = i + 2;
-            vo->col_type = c->color_type;
             vo->opacity = c->opacity;
             vo->col_channel = get_color_channel(c->color_type, obj_game, obj);
             viewable_objects_ptr[sprite_count] = vo;
@@ -701,8 +724,6 @@ static inline uint32_t make_sort_key(SpriteObject *s)
     if (id >= 15 && id <= 17 && s->layer == 2) {
         zlayer += 2;
     } 
-
-    s->zlayer = zlayer;
 
     // Pack all variables into a nice 32 bit variable
     uint32_t zl = (uint32_t)(zlayer + 8);     // fits in 6 bits
@@ -1135,13 +1156,12 @@ void create_objects() {
     // Only needs one as its only for sorting purposes
     SpriteObject *vo = &viewable_objects[sprite_count];
 
-    C2D_Sprite spr = { 0 };
-    vo->spr = spr;
     vo->obj = -1;
     vo->layer = 0;
-    vo->col_type = 0;
     vo->opacity = 1.f;
     vo->col_channel = 0;
+    vo->blending = false;
+    vo->visible = true;
     viewable_objects_ptr[sprite_count] = vo;
     sprite_count++;
 
@@ -1274,7 +1294,9 @@ void create_objects() {
             // Set opacity here
             if (obj->layer == 0) objects.opacity[game_object] = real_opacity / 255.f;
             
-            C2D_PlainImageTint(&obj->tint, C2D_Color32(col.color.r, col.color.g, col.color.b, real_opacity), 1.f);
+            obj->tint_color = C2D_Color32(col.color.r, col.color.g, col.color.b, real_opacity);
+            obj->blending = col.blending;
+            obj->visible = real_opacity > 0 && (!col.blending || (col.color.r | col.color.g | col.color.b) != 0);
         }
     }
 }
@@ -1338,36 +1360,64 @@ void draw_player_graphics() {
     draw_post_player_effects();
 }
 
+static void draw_object_range(size_t begin, size_t end) {
+    bool renderer_active = false;
+    C3D_Tex *batch_texture = NULL;
+    bool batch_blending = false;
+    int batch_first_slot = 0;
+    int batch_sprite_count = 0;
+
+    for (size_t s = begin; s < end; s++) {
+        SpriteObject *obj = viewable_objects_ptr[s];
+        if (obj->obj == -1 || !obj->visible) continue;
+
+        bool continues_batch = batch_sprite_count > 0
+            && obj->image.tex == batch_texture
+            && obj->blending == batch_blending
+            && obj->render_slot == batch_first_slot + batch_sprite_count;
+
+        if (!continues_batch && batch_sprite_count > 0) {
+            object_renderer_draw_batch(batch_first_slot, batch_sprite_count, batch_texture, batch_blending);
+            batch_sprite_count = 0;
+        }
+
+        if (batch_sprite_count == 0) {
+            if (!renderer_active) {
+                object_renderer_begin();
+                renderer_active = true;
+            }
+            batch_texture = obj->image.tex;
+            batch_blending = obj->blending;
+            batch_first_slot = obj->render_slot;
+        }
+        batch_sprite_count++;
+    }
+
+    if (batch_sprite_count > 0) {
+        object_renderer_draw_batch(batch_first_slot, batch_sprite_count, batch_texture, batch_blending);
+    }
+    if (renderer_active) {
+        object_renderer_end();
+        blending_state = false;
+    }
+}
+
 void draw_objects() {
     u64 start = svcGetSystemTick();
 
-    // Draw
-    for (size_t s = 0; s < sprite_count; s++) {
-        SpriteObject *obj = viewable_objects_ptr[s];
+    // The left eye is always first. Build the GPU buffer once after FrameBegin
+    // has synchronized with the previous frame, then reuse it for the right eye.
+    if (!is_extra_eye()) {
+        object_renderer_build(viewable_objects_ptr, sprite_count);
+    }
 
-        if (obj->obj != -1) {
-            int col_channel = obj->col_channel;
-            
-            ColorChannel col;
+    size_t player_pos = 0;
+    while (player_pos < sprite_count && viewable_objects_ptr[player_pos]->obj != -1) player_pos++;
 
-            if (col_channel < 0) {
-                col.color.r = 255;
-                col.color.g = 255;
-                col.color.b = 255;
-                col.blending = false;
-            } else {
-                col = channels[get_col_channel_index(col_channel)];
-            }
-
-            change_blending(col.blending);
-
-            // Cull invisible objects
-            if ((col.color.r | col.color.g | col.color.b) == 0 && col.blending) continue;
-            
-            C2D_DrawSpriteTinted(&obj->spr, &obj->tint);
-        } else {   
-            draw_player_graphics();
-        }
+    draw_object_range(0, player_pos);
+    if (player_pos < sprite_count) {
+        draw_player_graphics();
+        draw_object_range(player_pos + 1, sprite_count);
     }
 
     change_blending(true);

--- a/source/graphics.c
+++ b/source/graphics.c
@@ -807,13 +807,19 @@ static inline uint32_t make_sort_key(SpriteObject *s)
     int col_channel = s->col_channel;
 
     bool blending = col_channel > 0 && (channels[get_col_channel_index(col_channel)].blending ^ ((zlayer & 1) == 0));
+    bool inset_speed_glow = s->layer == 1 && id >= SLOW_SPEED_PORTAL && id <= FASTER_SPEED_PORTAL;
+
+    // A speed portal is intentionally sandwiched between the back and front
+    // halves of the other portals. Keep its glow in that same layer, directly
+    // behind its arrow, instead of applying the generic full-layer glow drop.
+    if (inset_speed_glow) blending = false;
 
     // If layer is a glow layer or it has blending, decrement it
-    if (s->layer == 1 || blending) {
+    if ((s->layer == 1 && !inset_speed_glow) || blending) {
         zlayer--;
     }
 
-    int child_z = 0;
+    int child_z = inset_speed_glow ? -1 : 0;
     int tex = game_obj->texture;
 
     // If layer is a glow layer, it does something for sure
@@ -827,7 +833,7 @@ static inline uint32_t make_sort_key(SpriteObject *s)
     // Glow layers always use spritesheet 2 (only for sorting purposes)
     int sheet;
     if (s->layer == 1) {
-        sheet = 2;
+        sheet = inset_speed_glow ? 0 : 2;
     } else {
         sheet = tex < SPRITESHEET2_START ? 1 : 0;
     }

--- a/source/graphics.c
+++ b/source/graphics.c
@@ -268,6 +268,8 @@ const float rightFadeBound = leftFadeBound + 110;
 const float rightFadeWidth = (SCREEN_WIDTH_AREA) - (leftFadeBound + 190);
 
 float get_fading_obj_fade(int obj, float right_edge, float *glow_out) {
+    *glow_out = 1.f;
+
     if (!state.dead) {
         // Offset fade checks slightly so invisible blocks
         // begin fading before reaching the actual boundary
@@ -544,21 +546,64 @@ static inline void set_sprite_render_data(
     sprite->flip_y = scale_y < 0.f;
 }
 
+static inline void prepare_sprite_color(SpriteObject *sprite, int edge_opacity, float fade_opacity) {
+    int col_channel = sprite->col_channel;
+    ColorChannel col;
+
+    if (col_channel < 0) {
+        col.color.r = 255;
+        col.color.g = 255;
+        col.color.b = 255;
+        col.blending = false;
+    } else if (col_channel == CHANNEL_INVISIBLE_GLOW) {
+        int chan = get_col_channel_index(CHANNEL_LBG_NOLERP);
+        Color lbg = channels[chan].color;
+        Color p1 = get_white_if_black(p1_color);
+        float opacity = objects.opacity[sprite->obj];
+
+        if (opacity < 0.8f || state.dead) {
+            col = channels[chan];
+        } else {
+            float blend_factor = 1.9f - 1.5f * opacity;
+            float one_minus_factor = 1.0f - blend_factor;
+
+            int r = (float)p1.r * one_minus_factor + (float)lbg.r * blend_factor;
+            int g = (float)p1.g * one_minus_factor + (float)lbg.g * blend_factor;
+            int b = (float)p1.b * one_minus_factor + (float)lbg.b * blend_factor;
+
+            col.color.r = CLAMP(r, 0, 255);
+            col.color.g = CLAMP(g, 0, 255);
+            col.color.b = CLAMP(b, 0, 255);
+            col.blending = true;
+        }
+    } else {
+        col = channels[get_col_channel_index(col_channel)];
+    }
+
+    int real_opacity = edge_opacity * sprite->opacity * fade_opacity;
+    sprite->tint_color = C2D_Color32(col.color.r, col.color.g, col.color.b, real_opacity);
+    sprite->blending = col.blending;
+    sprite->visible = real_opacity > 0 && (!col.blending || (col.color.r | col.color.g | col.color.b) != 0);
+}
+
 void spawn_object_at(
     int obj_game,
     int id,
     float x,
     float y,
-    float deg,
+    float sin_r,
+    float cos_r,
     unsigned char flip_x,
     unsigned char flip_y,
-    float scale
+    float scale,
+    int edge_opacity,
+    float fading_opacity,
+    float glow_opacity
 ) {
     const GameObject* obj = &game_objects[id];
 
-    float rad = C3D_AngleFromDegrees(adjust_angle(deg, 0, state.mirror_mult < 0));
-    float cos_r = cosf(rad);
-    float sin_r = sinf(rad);
+    // A vertical mirror negates the angle. Its cosine is unchanged.
+    if (state.mirror_mult < 0) sin_r = -sin_r;
 
     int flip_x_mult = (flip_x ? -1 : 1);
     int flip_y_mult = (flip_y ? -1 : 1);
@@ -572,6 +617,12 @@ void spawn_object_at(
     float sy = scale * flip_y_mult;
 
     if (sprite_count >= MAX_SPRITES - 1) return;
+
+    // Invisible glow channels depend on the parent opacity. Resolve it before
+    // spawning any layer so glow ordering cannot make it use the prior frame.
+    if (obj->texture >= 0) {
+        objects.opacity[obj_game] = (edge_opacity * obj->opacity * fading_opacity) / 255.f;
+    }
 
     // Spawn parent, skip if no texture
     if (obj->texture >= 0) {
@@ -604,6 +655,7 @@ void spawn_object_at(
         vo->layer = 0;
         vo->opacity = obj->opacity;
         vo->col_channel = get_color_channel(obj->color_type, obj_game, obj);
+        prepare_sprite_color(vo, edge_opacity, fading_opacity);
         viewable_objects_ptr[sprite_count] = vo;
         sprite_count++;
     }
@@ -623,6 +675,7 @@ void spawn_object_at(
         vo->layer = 1;
         vo->opacity = obj->opacity;
         vo->col_channel = get_glow_channel(obj_game);
+        prepare_sprite_color(vo, edge_opacity, glow_opacity);
         viewable_objects_ptr[sprite_count] = vo;
         sprite_count++;
     }
@@ -669,6 +722,7 @@ void spawn_object_at(
             vo->layer = i + 2;
             vo->opacity = c->opacity;
             vo->col_channel = get_color_channel(c->color_type, obj_game, obj);
+            prepare_sprite_color(vo, edge_opacity, fading_opacity);
             viewable_objects_ptr[sprite_count] = vo;
             sprite_count++;
         }
@@ -819,9 +873,8 @@ float get_out_scale_fade(float x, int right_edge) {
     return 1 + ((fade / 255.f) / 2);
 }
 
-// Some objects dont change opacity on fade transitions
-int get_obj_opacity(int obj, float x) {
-    int opacity = obj_edge_fade(x, SCREEN_WIDTH / SCALE);
+// Some objects dont change opacity on fade transitions.
+static int get_obj_opacity_from_fade(int obj, int opacity) {
     bool blending;
 
     switch (objects.id[obj]) {
@@ -859,6 +912,10 @@ int get_obj_opacity(int obj, float x) {
     }
 
     return opacity;
+}
+
+int get_obj_opacity(int obj, float x) {
+    return get_obj_opacity_from_fade(obj, obj_edge_fade(x, SCREEN_WIDTH / SCALE));
 }
 
 // Handle complex fading transitions
@@ -913,51 +970,57 @@ void handle_special_fading(int obj, float calc_x, float calc_y) {
     }   
 }
 
-void get_fade_vars(int obj, float x, int *fade_x, int *fade_y, float *fade_scale) {
+static void get_fade_vars_from_value(int obj, int fade, int *fade_x, int *fade_y, float *fade_scale) {
+    int offset = (255 - fade) / 2;
+
     switch (objects.transition_applied[obj]) {
         case FADE_NONE:
             break;
         case FADE_UP:
-            *fade_y = get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
+            *fade_y = offset;
             break;
         case FADE_DOWN:
-            *fade_y = -get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
+            *fade_y = -offset;
             break;
         case FADE_RIGHT:
-            *fade_x = get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
+            *fade_x = offset;
             break;
         case FADE_LEFT:
-            *fade_x = -get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
+            *fade_x = -offset;
             break;
         case FADE_SCALE_IN:
-            *fade_scale = get_in_scale_fade(x, SCREEN_WIDTH / SCALE);
+            *fade_scale = fade / 255.f;
             break;
         case FADE_SCALE_OUT:
-            *fade_scale = get_out_scale_fade(x, SCREEN_WIDTH / SCALE);
+            *fade_scale = 1.f + ((255 - fade) / 255.f) / 2.f;
             break;
         case FADE_UP_SLOW_LEFT:
-            *fade_x = -get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
-            *fade_y = get_xy_fade_offset(x, SCREEN_WIDTH / SCALE) / 3;
+            *fade_x = -offset;
+            *fade_y = offset / 3;
             break;
         case FADE_UP_SLOW_RIGHT:
-            *fade_x = get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
-            *fade_y = get_xy_fade_offset(x, SCREEN_WIDTH / SCALE) / 3;
+            *fade_x = offset;
+            *fade_y = offset / 3;
             break;
         case FADE_UP_STATIONARY:
-            *fade_y = get_xy_fade_offset(x, SCREEN_WIDTH / SCALE) / 3;
+            *fade_y = offset / 3;
             break;
         case FADE_DOWN_SLOW_LEFT:
-            *fade_x = -get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
-            *fade_y = -get_xy_fade_offset(x, SCREEN_WIDTH / SCALE) / 3;
+            *fade_x = -offset;
+            *fade_y = -offset / 3;
             break;
         case FADE_DOWN_SLOW_RIGHT:
-            *fade_x = get_xy_fade_offset(x, SCREEN_WIDTH / SCALE);
-            *fade_y = -get_xy_fade_offset(x, SCREEN_WIDTH / SCALE) / 3;
+            *fade_x = offset;
+            *fade_y = -offset / 3;
             break;
         case FADE_DOWN_STATIONARY:
-            *fade_y = -get_xy_fade_offset(x, SCREEN_WIDTH / SCALE) / 3;
+            *fade_y = -offset / 3;
             break;
     }
+}
+
+void get_fade_vars(int obj, float x, int *fade_x, int *fade_y, float *fade_scale) {
+    get_fade_vars_from_value(obj, obj_edge_fade(x, SCREEN_WIDTH / SCALE), fade_x, fade_y, fade_scale);
 }
 
 void get_special_fading_vars(int obj, float fade_val, float *calc_x) {
@@ -1152,6 +1215,15 @@ float object_drawing_time = 0;
 void create_objects() {
     sprite_count = 0;
 
+    // Saw speeds are limited to 180 or 360 degrees per second. Compute both
+    // frame steps once, then advance each visible saw with angle addition.
+    float step_180 = C3D_AngleFromDegrees(180.f * delta);
+    float step_360 = C3D_AngleFromDegrees(360.f * delta);
+    float step_180_sin = sinf(step_180);
+    float step_180_cos = cosf(step_180);
+    float step_360_sin = sinf(step_360);
+    float step_360_cos = cosf(step_360);
+
     // Player sprite
     // Only needs one as its only for sorting purposes
     SpriteObject *vo = &viewable_objects[sprite_count];
@@ -1201,23 +1273,61 @@ void create_objects() {
 
                 float fade_scale = 1.f;
 
-                get_fade_vars(obj, calc_x, &fade_x, &fade_y, &fade_scale);
+                get_fade_vars_from_value(obj, fade_val, &fade_x, &fade_y, &fade_scale);
 
                 // Handle saw rotation
-                objects.rotation[obj] += (((objects.random[obj] & 1) ? -get_rotation_speed(objects.id[obj]) : get_rotation_speed(objects.id[obj]))) * delta;
+                float rotation_sin = objects.rotation_sin[obj];
+                float rotation_cos = objects.rotation_cos[obj];
+                float rotation_speed = get_rotation_speed(objects.id[obj]);
+                if (rotation_speed != 0.f) {
+                    bool reverse = (objects.random[obj] & 1) != 0;
+                    float step_sin = rotation_speed == 360.f ? step_360_sin : step_180_sin;
+                    float step_cos = rotation_speed == 360.f ? step_360_cos : step_180_cos;
+                    if (reverse) {
+                        rotation_speed = -rotation_speed;
+                        step_sin = -step_sin;
+                    }
+
+                    objects.rotation[obj] += rotation_speed * delta;
+                    float old_sin = rotation_sin;
+                    rotation_sin = old_sin * step_cos + rotation_cos * step_sin;
+                    rotation_cos = rotation_cos * step_cos - old_sin * step_sin;
+
+                    // Bound floating-point drift without returning to per-object
+                    // trigonometry on every frame.
+                    if ((level_frame & 0x1ff) == 0) {
+                        float radians = C3D_AngleFromDegrees(objects.rotation[obj]);
+                        rotation_sin = sinf(radians);
+                        rotation_cos = cosf(radians);
+                    }
+
+                    objects.rotation_sin[obj] = rotation_sin;
+                    objects.rotation_cos[obj] = rotation_cos;
+                }
                 
                 // Handle special fade types
                 get_special_fading_vars(obj, fade_val, &calc_x);
+
+                int edge_opacity = get_obj_opacity_from_fade(obj, fade_val);
+                float fading_opacity = 1.f;
+                float glow_opacity = 1.f;
+                if (object_fades(obj)) {
+                    fading_opacity = get_fading_obj_fade(obj, SCREEN_WIDTH / SCALE, &glow_opacity);
+                }
 
                 spawn_object_at(
                     obj,
                     objects.id[obj],
                     get_mirror_x(calc_x + fade_x, state.mirror_factor),
                     calc_y + fade_y,
-                    objects.rotation[obj],
+                    rotation_sin,
+                    rotation_cos,
                     objects.flippedH[obj] ^ (state.mirror_mult < 0),
                     objects.flippedV[obj],
-                    fade_scale
+                    fade_scale,
+                    edge_opacity,
+                    fading_opacity,
+                    glow_opacity
                 );
 
                 spawn_object_particles(obj);
@@ -1235,70 +1345,6 @@ void create_objects() {
     end = svcGetSystemTick();
     ticks = end - start;
     object_sorting_time = ticks / CPU_TICKS_PER_MSEC;
-
-    for (size_t s = 0; s < sprite_count; s++) {
-        SpriteObject *obj = viewable_objects_ptr[s];
-        if (obj->obj != -1) {
-            int col_channel = obj->col_channel;
-
-            ColorChannel col;
-
-            if (col_channel < 0) {
-                col.color.r = 255;
-                col.color.g = 255;
-                col.color.b = 255;
-                col.blending = false;
-            } else if (col_channel == CHANNEL_INVISIBLE_GLOW) { // Handle invisible blocks color lerping
-                int chan = get_col_channel_index(CHANNEL_LBG_NOLERP);
-
-                Color lbg = channels[chan].color;
-                Color p1 = get_white_if_black(p1_color);
-                float opacity = objects.opacity[obj->obj];
-
-                if (opacity < 0.8f || state.dead) {
-                    col = channels[chan];
-                } else {
-                    float blendFactor = 1.9f - 1.5f * opacity;
-                    float oneMinusFactor = 1.0f - blendFactor;
-
-                    int r = (float)p1.r * oneMinusFactor + (float)lbg.r * blendFactor;
-                    int g = (float)p1.g * oneMinusFactor + (float)lbg.g * blendFactor;
-                    int b = (float)p1.b * oneMinusFactor + (float)lbg.b * blendFactor;
-                    
-                    col.color.r = CLAMP(r, 0, 255);
-                    col.color.g = CLAMP(g, 0, 255);
-                    col.color.b = CLAMP(b, 0, 255);
-                    col.blending = true;
-                }
-            } else {
-                col = channels[get_col_channel_index(col_channel)];
-            }
-            
-            int game_object = obj->obj;
-            float x = ((objects.x[game_object] - state.camera_x));
-            
-            float opacity = obj->opacity;
-
-            // Handle invisible object opacity
-            if (object_fades(game_object)) {
-                float glow_out;
-                float fading_opacity = get_fading_obj_fade(game_object, SCREEN_WIDTH / SCALE, &glow_out);
-                
-                // Check if layer is glow
-                if (obj->layer == 1) opacity *= glow_out;
-                else opacity *= fading_opacity;
-            }
-
-            int real_opacity = get_obj_opacity(game_object, x) * opacity;
-
-            // Set opacity here
-            if (obj->layer == 0) objects.opacity[game_object] = real_opacity / 255.f;
-            
-            obj->tint_color = C2D_Color32(col.color.r, col.color.g, col.color.b, real_opacity);
-            obj->blending = col.blending;
-            obj->visible = real_opacity > 0 && (!col.blending || (col.color.r | col.color.g | col.color.b) != 0);
-        }
-    }
 }
 
 void draw_player_effects() {

--- a/source/graphics.c
+++ b/source/graphics.c
@@ -79,9 +79,7 @@ enum ObjectFadeOpacityMode {
     OBJECT_FADE_DETAIL_IF_OPAQUE,
 };
 
-static float frame_pulse_amplitude = 1.f;
-static float frame_pulse_wide = 1.f;
-static float frame_pulse_narrow = 1.f;
+float object_pulse_scales[4] = { 1.f, 1.f, 1.f, 1.f };
 
 static float get_rotation_speed_for_id(int id);
 static int get_glow_channel_for_id(int id, bool fades);
@@ -536,18 +534,18 @@ static u8 get_object_pulse_mode(int id) {
     return OBJECT_PULSE_NONE;
 }
 
-static inline float get_cached_object_pulse(int id, int layer) {
+static inline u8 get_cached_object_pulse_index(int id, int layer) {
     switch (sprite_templates[id].pulse_mode) {
         case OBJECT_PULSE_AMPLITUDE:
-            return frame_pulse_amplitude;
+            return 1;
         case OBJECT_PULSE_WIDE:
-            return frame_pulse_wide;
+            return 2;
         case OBJECT_PULSE_NARROW:
-            return frame_pulse_narrow;
+            return 3;
         case OBJECT_PULSE_ROD_CHILD:
-            return layer == 2 ? frame_pulse_amplitude : 1.f;
+            return layer == 2 ? 1 : 0;
         default:
-            return 1.f;
+            return 0;
     }
 }
 
@@ -591,6 +589,8 @@ static inline void set_sprite_render_data(
     const C2D_Image image,
     float x,
     float y,
+    float offset_x,
+    float offset_y,
     float scale_x,
     float scale_y,
     float rotation_sin,
@@ -599,12 +599,25 @@ static inline void set_sprite_render_data(
     sprite->image = image;
     sprite->x = x;
     sprite->y = y;
+    sprite->offset_x = offset_x;
+    sprite->offset_y = offset_y;
     sprite->half_width = fabsf(scale_x * image.subtex->width) * 0.5f;
     sprite->half_height = fabsf(scale_y * image.subtex->height) * 0.5f;
     sprite->rotation_sin = rotation_sin;
     sprite->rotation_cos = rotation_cos;
     sprite->flip_x = scale_x < 0.f;
     sprite->flip_y = scale_y < 0.f;
+}
+
+static inline void prepare_sprite_transform(
+    SpriteObject *sprite,
+    int fade_value,
+    u8 fade_transition,
+    u8 pulse_index
+) {
+    sprite->fade_meta = (u32)(fade_value & 0xff)
+        | ((u32)fade_transition << 8)
+        | ((u32)pulse_index << 16);
 }
 
 static inline void prepare_sprite_color(SpriteObject *sprite, int edge_opacity, float fade_opacity) {
@@ -655,14 +668,16 @@ void spawn_object_at(
     float cos_r,
     unsigned char flip_x,
     unsigned char flip_y,
-    float scale,
     int edge_opacity,
     float fading_opacity,
-    float glow_opacity
+    float glow_opacity,
+    int fade_value,
+    u8 fade_transition
 ) {
     const GameObject* obj = &game_objects[id];
 
-    // A vertical mirror negates the angle. Its cosine is unchanged.
+    // Child rotations are relative to the mirrored parent angle in the
+    // original renderer, so retain this discrete orientation step on CPU.
     if (state.mirror_mult < 0) sin_r = -sin_r;
 
     int flip_x_mult = (flip_x ? -1 : 1);
@@ -673,8 +688,8 @@ void spawn_object_at(
     float m10 = sin_r;
     float m11 = -cos_r;
 
-    float sx = scale * flip_x_mult;
-    float sy = scale * flip_y_mult;
+    float sx = flip_x_mult;
+    float sy = flip_y_mult;
 
     if (sprite_count >= MAX_SPRITES - 1) return;
 
@@ -694,9 +709,6 @@ void spawn_object_at(
         float rot_x = local_x * m00 + local_y * m01;
         float rot_y = local_x * m10 + local_y * m11;
 
-        float p_x = x + rot_x * scale;
-        float p_y = y + rot_y * scale;
-
         int random_layer = get_obj_random_layer(obj_game, id);
         C2D_Image image;
         if (random_layer < 0) {
@@ -707,15 +719,14 @@ void spawn_object_at(
             image = C2D_SpriteSheetGetImage(*sheet, rel_index);
         }
 
-        float pulse_scale = get_cached_object_pulse(id, 0);
-
-        set_sprite_render_data(vo, image, p_x, p_y, sx * pulse_scale, sy * pulse_scale, sin_r, cos_r);
+        set_sprite_render_data(vo, image, x, y, rot_x, rot_y, sx, sy, sin_r, cos_r);
 
         vo->obj = obj_game;
         vo->layer = 0;
         vo->opacity = obj->opacity;
         vo->col_channel = get_color_channel(obj->color_type, obj_game, obj);
         prepare_sprite_color(vo, edge_opacity, fading_opacity);
+        prepare_sprite_transform(vo, fade_value, fade_transition, get_cached_object_pulse_index(id, 0));
         viewable_objects_ptr[sprite_count] = vo;
         sprite_count++;
     }
@@ -726,16 +737,15 @@ void spawn_object_at(
 
         SpriteObject *vo = &viewable_objects[sprite_count];
 
-        float pulse_scale = get_cached_object_pulse(id, 1);
-
         set_sprite_render_data(vo, sprite_templates[id].glow_template.image,
-            x, y, sx * pulse_scale, sy * pulse_scale, sin_r, cos_r);
+            x, y, 0.f, 0.f, sx, sy, sin_r, cos_r);
 
         vo->obj = obj_game;
         vo->layer = 1;
         vo->opacity = obj->opacity;
         vo->col_channel = get_glow_channel(obj_game);
         prepare_sprite_color(vo, edge_opacity, glow_opacity);
+        prepare_sprite_transform(vo, fade_value, fade_transition, get_cached_object_pulse_index(id, 1));
         viewable_objects_ptr[sprite_count] = vo;
         sprite_count++;
     }
@@ -756,25 +766,21 @@ void spawn_object_at(
             float c_rot_x = c_local_x * m00 + c_local_y * m01;
             float c_rot_y = c_local_x * m10 + c_local_y * m11;
 
-            float c_x = x + c_rot_x * scale;
-            float c_y = y + c_rot_y * scale;
-
             int c_flip_x_mult = (c->flip_x ? -1 : 1);
             int c_flip_y_mult = (c->flip_y ? -1 : 1);
 
-            float pulse_scale = get_cached_object_pulse(id, i + 2);
             const ChildSpriteTemplate *child_template = &sprite_templates[id].child_templates[i];
             if (id < 15 || id > 17) {
                 float child_sin = sin_r * child_template->rotation_cos + cos_r * child_template->rotation_sin;
                 float child_cos = cos_r * child_template->rotation_cos - sin_r * child_template->rotation_sin;
-                set_sprite_render_data(vo, child_template->sprite.image, c_x, c_y,
-                    c->scale_x * c_flip_x_mult * sx * pulse_scale,
-                    c->scale_y * c_flip_y_mult * sy * pulse_scale,
+                set_sprite_render_data(vo, child_template->sprite.image, x, y, c_rot_x, c_rot_y,
+                    c->scale_x * c_flip_x_mult * sx,
+                    c->scale_y * c_flip_y_mult * sy,
                     child_sin, child_cos);
             } else {
-                set_sprite_render_data(vo, child_template->sprite.image, c_x, c_y,
-                    fabsf(c->scale_x * c_flip_x_mult * sx * pulse_scale),
-                    fabsf(c->scale_y * c_flip_y_mult * sy * pulse_scale),
+                set_sprite_render_data(vo, child_template->sprite.image, x, y, c_rot_x, c_rot_y,
+                    fabsf(c->scale_x * c_flip_x_mult * sx),
+                    fabsf(c->scale_y * c_flip_y_mult * sy),
                     0.f, 1.f);
             }
 
@@ -783,6 +789,7 @@ void spawn_object_at(
             vo->opacity = c->opacity;
             vo->col_channel = get_color_channel(c->color_type, obj_game, obj);
             prepare_sprite_color(vo, edge_opacity, fading_opacity);
+            prepare_sprite_transform(vo, fade_value, fade_transition, get_cached_object_pulse_index(id, i + 2));
             viewable_objects_ptr[sprite_count] = vo;
             sprite_count++;
         }
@@ -1260,11 +1267,11 @@ float object_drawing_time = 0;
 void create_objects() {
     sprite_count = 0;
 
-    frame_pulse_amplitude = amplitude;
-    frame_pulse_amplitude *= music_volume > 0 && global_volume > 0;
-    frame_pulse_amplitude = MAX(0.1f, frame_pulse_amplitude);
-    frame_pulse_wide = 0.3f + frame_pulse_amplitude * 0.9f;
-    frame_pulse_narrow = 0.6f + frame_pulse_amplitude * 0.6f;
+    object_pulse_scales[0] = 1.f;
+    object_pulse_scales[1] = amplitude * (music_volume > 0 && global_volume > 0);
+    object_pulse_scales[1] = MAX(0.1f, object_pulse_scales[1]);
+    object_pulse_scales[2] = 0.3f + object_pulse_scales[1] * 0.9f;
+    object_pulse_scales[3] = 0.6f + object_pulse_scales[1] * 0.6f;
 
     // Saw speeds are limited to 180 or 360 degrees per second. Compute both
     // frame steps once, then advance each visible saw with angle addition.
@@ -1325,15 +1332,7 @@ void create_objects() {
                         handle_special_fading(obj, calc_x, calc_y);
                     }
                 }
-                int fade_x = 0;
-                int fade_y = 0;
-
-                float fade_scale = 1.f;
-
                 u8 fade_transition = objects.transition_applied[obj];
-                if (fade_transition != FADE_NONE) {
-                    get_fade_vars_from_value(obj, fade_val, &fade_x, &fade_y, &fade_scale);
-                }
 
                 // Handle saw rotation
                 float rotation_sin = objects.rotation_sin[obj];
@@ -1365,9 +1364,13 @@ void create_objects() {
                     objects.rotation_cos[obj] = rotation_cos;
                 }
                 
-                // Handle special fade types
+                // Stationary transitions pin the object root at an edge. The
+                // shader handles their remaining translation and scale.
+                float render_world_x = objects.x[obj];
                 if (fade_transition == FADE_DOWN_STATIONARY || fade_transition == FADE_UP_STATIONARY) {
-                    get_special_fading_vars(obj, fade_val, &calc_x);
+                    float stationary_x = calc_x;
+                    get_special_fading_vars(obj, fade_val, &stationary_x);
+                    render_world_x = state.camera_x + stationary_x;
                 }
 
                 int edge_opacity = get_obj_opacity_from_fade(obj, fade_val);
@@ -1380,16 +1383,17 @@ void create_objects() {
                 spawn_object_at(
                     obj,
                     objects.id[obj],
-                    get_mirror_x(calc_x + fade_x, state.mirror_factor),
-                    calc_y + fade_y,
+                    render_world_x,
+                    objects.y[obj],
                     rotation_sin,
                     rotation_cos,
                     objects.flippedH[obj] ^ (state.mirror_mult < 0),
                     objects.flippedV[obj],
-                    fade_scale,
                     edge_opacity,
                     fading_opacity,
-                    glow_opacity
+                    glow_opacity,
+                    fade_val,
+                    fade_transition
                 );
 
                 if (sprite_templates[objects.id[obj]].has_particles) {

--- a/source/graphics.c
+++ b/source/graphics.c
@@ -64,6 +64,30 @@ SpriteTemplate sprite_templates[GAME_OBJECT_COUNT]; // global cache
 
 float touch_effect_drag_timer = 0.f;
 
+enum ObjectPulseMode {
+    OBJECT_PULSE_NONE,
+    OBJECT_PULSE_AMPLITUDE,
+    OBJECT_PULSE_WIDE,
+    OBJECT_PULSE_NARROW,
+    OBJECT_PULSE_ROD_CHILD,
+};
+
+enum ObjectFadeOpacityMode {
+    OBJECT_FADE_NORMAL,
+    OBJECT_FADE_ALWAYS_OPAQUE,
+    OBJECT_FADE_BASE_IF_OPAQUE,
+    OBJECT_FADE_DETAIL_IF_OPAQUE,
+};
+
+static float frame_pulse_amplitude = 1.f;
+static float frame_pulse_wide = 1.f;
+static float frame_pulse_narrow = 1.f;
+
+static float get_rotation_speed_for_id(int id);
+static int get_glow_channel_for_id(int id, bool fades);
+static u8 get_object_pulse_mode(int id);
+static u8 get_fade_opacity_mode_for_id(int id);
+
 static C2D_SpriteSheet *get_sprite_sheet(int index, int *rel_index) {
     // Check if index belongs to spritesheet 1 (most objects)
     if (index < SPRITESHEET2_START) {
@@ -140,6 +164,15 @@ void cache_all_sprites() {
     for (int id = 0; id < GAME_OBJECT_COUNT; id++) {
         const GameObject* obj = &game_objects[id];
 
+        sprite_templates[id].rotation_speed = get_rotation_speed_for_id(id);
+        sprite_templates[id].fades = id == 144 || id == 145 || id == 146 || id == 147
+            || id == 204 || id == 205 || id == 206 || id == 459
+            || id == 673 || id == 674 || id == 740 || id == 741 || id == 742;
+        sprite_templates[id].glow_channel = get_glow_channel_for_id(id, sprite_templates[id].fades);
+        sprite_templates[id].pulse_mode = get_object_pulse_mode(id);
+        sprite_templates[id].fade_opacity_mode = get_fade_opacity_mode_for_id(id);
+        sprite_templates[id].has_particles = object_uses_particles(id);
+
         // Skip if object has no texture
         if (obj->texture < 0) continue;
 
@@ -205,23 +238,7 @@ float mirror_angle(float angle, bool hflip, bool vflip) {
 
 // Returns true if the object is a invisible object
 bool object_fades(int obj) {
-    switch (objects.id[obj]) {
-        case 144:
-        case 145:
-        case 146:
-        case 147:
-        case 204:
-        case 205:
-        case 206:
-        case 459:
-        case 673:
-        case 674:
-        case 740:
-        case 741:
-        case 742:
-            return true;
-    }
-    return false;
+    return sprite_templates[objects.id[obj]].fades;
 }
 
 inline int get_color_channel(int col_type, int obj, const GameObject *game_obj) {
@@ -343,13 +360,13 @@ float get_fading_obj_fade(int obj, float right_edge, float *glow_out) {
     return 1.f;
 }
 
-// Get the glow color channel
-int get_glow_channel(int obj) {
-    if (object_fades(obj)) {
+// Get the glow color channel. This depends only on the object definition, so
+// cache it with the sprite template instead of switching for every instance.
+static int get_glow_channel_for_id(int id, bool fades) {
+    if (fades) {
         return CHANNEL_INVISIBLE_GLOW;
     }
 
-    int id = objects.id[obj];
     switch (id) {
         case 143:
         case 177:
@@ -402,6 +419,10 @@ int get_glow_channel(int obj) {
     return CHANNEL_OBJ_BLENDING;
 }
 
+int get_glow_channel(int obj) {
+    return sprite_templates[objects.id[obj]].glow_channel;
+}
+
 int get_coin_texture(int tex, int ticks) {
     return tex + ((level_frame / ticks) & 0b11);;
 }
@@ -427,7 +448,7 @@ int get_obj_random_layer(int obj, int id) {
 }
 
 // Deco saws rotate slower than normal saws. If not a saw, rotation speed is just 0
-float get_rotation_speed(int id) {
+static float get_rotation_speed_for_id(int id) {
     switch (id) {
         case 88: 
         case 89:
@@ -480,23 +501,16 @@ float get_rotation_speed(int id) {
     return 0.f;
 }
 
-// Map amplitude pulsing to ranges
-float get_object_pulse(float amplitude, int id, int layer) {
-     // No pulse if one of those is 0
-    amplitude *= music_volume > 0 && global_volume > 0;
-    amplitude = MAX(0.1f, amplitude); // Cap at 0.1
+static u8 get_object_pulse_mode(int id) {
     switch (id) {
         case 36:
         case 84:
         case 141:
-            return map_range(amplitude, 0.f, 1.f, 0.3f, 1.2f);
+            return OBJECT_PULSE_WIDE;
         case 15:
         case 16:
         case 17:
-            if (layer == 2) {    
-                return amplitude;
-            }
-            return 1.0f;
+            return OBJECT_PULSE_ROD_CHILD;
         case 50:
         case 51:
         case 52:
@@ -506,7 +520,7 @@ float get_object_pulse(float amplitude, int id, int layer) {
         case 148:
         case 149:
         case 405:
-            return amplitude;
+            return OBJECT_PULSE_AMPLITUDE;
         case 132:
         case 133:
         case 136:
@@ -517,9 +531,56 @@ float get_object_pulse(float amplitude, int id, int layer) {
         case 495:
         case 496:
         case 497:
-            return map_range(amplitude, 0.f, 1.f, 0.6f, 1.2f);
+            return OBJECT_PULSE_NARROW;
     }
-    return 1.0f;
+    return OBJECT_PULSE_NONE;
+}
+
+static inline float get_cached_object_pulse(int id, int layer) {
+    switch (sprite_templates[id].pulse_mode) {
+        case OBJECT_PULSE_AMPLITUDE:
+            return frame_pulse_amplitude;
+        case OBJECT_PULSE_WIDE:
+            return frame_pulse_wide;
+        case OBJECT_PULSE_NARROW:
+            return frame_pulse_narrow;
+        case OBJECT_PULSE_ROD_CHILD:
+            return layer == 2 ? frame_pulse_amplitude : 1.f;
+        default:
+            return 1.f;
+    }
+}
+
+static u8 get_fade_opacity_mode_for_id(int id) {
+    switch (id) {
+        case 90:
+        case 91:
+        case 92:
+        case 93:
+        case 94:
+        case 95:
+        case 96:
+        case 309:
+        case 311:
+        case 687:
+        case 688:
+            return OBJECT_FADE_ALWAYS_OPAQUE;
+        case 211:
+            return OBJECT_FADE_BASE_IF_OPAQUE;
+        case 207:
+        case 208:
+        case 209:
+        case 210:
+        case 212:
+        case 213:
+        case 331:
+        case 333:
+        case 693:
+        case 694:
+            return OBJECT_FADE_DETAIL_IF_OPAQUE;
+        default:
+            return OBJECT_FADE_NORMAL;
+    }
 }
 
 // Keep the compact per-object transform in the render list. The raw Citro3D
@@ -549,41 +610,40 @@ static inline void set_sprite_render_data(
 static inline void prepare_sprite_color(SpriteObject *sprite, int edge_opacity, float fade_opacity) {
     int col_channel = sprite->col_channel;
     ColorChannel col;
+    int channel_index;
+    bool mix_invisible_glow = false;
 
     if (col_channel < 0) {
+        channel_index = COL_CHANNEL_NUM;
         col.color.r = 255;
         col.color.g = 255;
         col.color.b = 255;
         col.blending = false;
     } else if (col_channel == CHANNEL_INVISIBLE_GLOW) {
-        int chan = get_col_channel_index(CHANNEL_LBG_NOLERP);
-        Color lbg = channels[chan].color;
-        Color p1 = get_white_if_black(p1_color);
+        channel_index = get_col_channel_index(CHANNEL_LBG_NOLERP);
+        col = channels[channel_index];
         float opacity = objects.opacity[sprite->obj];
 
-        if (opacity < 0.8f || state.dead) {
-            col = channels[chan];
-        } else {
-            float blend_factor = 1.9f - 1.5f * opacity;
-            float one_minus_factor = 1.0f - blend_factor;
-
-            int r = (float)p1.r * one_minus_factor + (float)lbg.r * blend_factor;
-            int g = (float)p1.g * one_minus_factor + (float)lbg.g * blend_factor;
-            int b = (float)p1.b * one_minus_factor + (float)lbg.b * blend_factor;
-
-            col.color.r = CLAMP(r, 0, 255);
-            col.color.g = CLAMP(g, 0, 255);
-            col.color.b = CLAMP(b, 0, 255);
+        if (opacity >= 0.8f && !state.dead) {
+            mix_invisible_glow = true;
             col.blending = true;
         }
     } else {
-        col = channels[get_col_channel_index(col_channel)];
+        channel_index = get_col_channel_index(col_channel);
+        col = channels[channel_index];
     }
 
     int real_opacity = edge_opacity * sprite->opacity * fade_opacity;
-    sprite->tint_color = C2D_Color32(col.color.r, col.color.g, col.color.b, real_opacity);
+    int parent_opacity = mix_invisible_glow
+        ? CLAMP((int)(objects.opacity[sprite->obj] * 255.f), 0, 255)
+        : 0;
+    sprite->color_meta = (u32)channel_index
+        | ((u32)(real_opacity & 0xff) << 8)
+        | ((u32)parent_opacity << 16)
+        | ((u32)mix_invisible_glow << 24);
     sprite->blending = col.blending;
-    sprite->visible = real_opacity > 0 && (!col.blending || (col.color.r | col.color.g | col.color.b) != 0);
+    sprite->visible = real_opacity > 0
+        && (mix_invisible_glow || !col.blending || (col.color.r | col.color.g | col.color.b) != 0);
 }
 
 void spawn_object_at(
@@ -647,7 +707,7 @@ void spawn_object_at(
             image = C2D_SpriteSheetGetImage(*sheet, rel_index);
         }
 
-        float pulse_scale = get_object_pulse(amplitude, id, 0);
+        float pulse_scale = get_cached_object_pulse(id, 0);
 
         set_sprite_render_data(vo, image, p_x, p_y, sx * pulse_scale, sy * pulse_scale, sin_r, cos_r);
 
@@ -666,7 +726,7 @@ void spawn_object_at(
 
         SpriteObject *vo = &viewable_objects[sprite_count];
 
-        float pulse_scale = get_object_pulse(amplitude, id, 1);
+        float pulse_scale = get_cached_object_pulse(id, 1);
 
         set_sprite_render_data(vo, sprite_templates[id].glow_template.image,
             x, y, sx * pulse_scale, sy * pulse_scale, sin_r, cos_r);
@@ -702,7 +762,7 @@ void spawn_object_at(
             int c_flip_x_mult = (c->flip_x ? -1 : 1);
             int c_flip_y_mult = (c->flip_y ? -1 : 1);
 
-            float pulse_scale = get_object_pulse(amplitude, id, i + 2);
+            float pulse_scale = get_cached_object_pulse(id, i + 2);
             const ChildSpriteTemplate *child_template = &sprite_templates[id].child_templates[i];
             if (id < 15 || id > 17) {
                 float child_sin = sin_r * child_template->rotation_cos + cos_r * child_template->rotation_sin;
@@ -735,7 +795,7 @@ static inline uint32_t make_sort_key(SpriteObject *s)
 
     // Player sprite is -1 so handle it there
     if (obj == -1) {
-        return ((5 + 8) << 18) | (0 << 16) | (0 << 8) | 0;
+        return (5 + 8) << 19;
     }
 
     const int id = objects.id[obj];
@@ -779,14 +839,16 @@ static inline uint32_t make_sort_key(SpriteObject *s)
         zlayer += 2;
     } 
 
-    // Pack all variables into a nice 32 bit variable
-    uint32_t zl = (uint32_t)(zlayer + 8);     // fits in 6 bits
-    uint32_t zb = (uint32_t)(blending);       // fits in 1 bit
-    uint32_t zs = (uint32_t)(sheet);          // fits in 1 bit
+    // Combine blending and sheet order into one real three-bit field. Glow
+    // uses sheet value 2, so the old one-bit packing collided with blending
+    // and could put otherwise identical layers on the wrong side of each
+    // other. Five z-layer bits retain the three-pass radix sort.
+    uint32_t zl = (uint32_t)CLAMP(zlayer + 8, 0, 31);
+    uint32_t material = (uint32_t)blending * 3 + (uint32_t)sheet;
     uint32_t zo = (uint32_t)(zorder + 128);   // fits in 8 bits
     uint32_t cz = (uint32_t)(child_z + 128);  // fits in 8 bits
 
-    return (zl << 18) | (zb << 17) | (zs << 16) | (zo << 8) | cz;
+    return (zl << 19) | (material << 16) | (zo << 8) | cz;
 }
 
 #define VIEW_OBJECTS (12 * 6)
@@ -875,39 +937,16 @@ float get_out_scale_fade(float x, int right_edge) {
 
 // Some objects dont change opacity on fade transitions.
 static int get_obj_opacity_from_fade(int obj, int opacity) {
-    bool blending;
+    if (objects.transition_applied[obj] != FADE_NONE) return opacity;
 
-    switch (objects.id[obj]) {
-        case 90:
-        case 91:
-        case 92:
-        case 93:
-        case 94:
-        case 95:
-        case 96:
-        case 309:
-        case 311:
-        case 687:
-        case 688:
-            if (objects.transition_applied[obj] == FADE_NONE) opacity = 255;
+    switch (sprite_templates[objects.id[obj]].fade_opacity_mode) {
+        case OBJECT_FADE_ALWAYS_OPAQUE:
+            return 255;
+        case OBJECT_FADE_BASE_IF_OPAQUE:
+            if (!channels[get_col_channel_index(objects.col_channel[obj])].blending) return 255;
             break;
-            
-        case 211:
-            blending = channels[get_col_channel_index(objects.col_channel[obj])].blending;
-            if (!blending && objects.transition_applied[obj] == FADE_NONE) opacity = 255;
-            break;
-        case 207:
-        case 208:
-        case 209:
-        case 210:
-        case 212:
-        case 213:
-        case 693:
-        case 694:
-        case 331:
-        case 333:
-            blending = channels[get_col_channel_index(objects.detail_col_channel[obj])].blending;
-            if (!blending && objects.transition_applied[obj] == FADE_NONE) opacity = 255;
+        case OBJECT_FADE_DETAIL_IF_OPAQUE:
+            if (!channels[get_col_channel_index(objects.detail_col_channel[obj])].blending) return 255;
             break;
     }
 
@@ -1215,6 +1254,12 @@ float object_drawing_time = 0;
 void create_objects() {
     sprite_count = 0;
 
+    frame_pulse_amplitude = amplitude;
+    frame_pulse_amplitude *= music_volume > 0 && global_volume > 0;
+    frame_pulse_amplitude = MAX(0.1f, frame_pulse_amplitude);
+    frame_pulse_wide = 0.3f + frame_pulse_amplitude * 0.9f;
+    frame_pulse_narrow = 0.6f + frame_pulse_amplitude * 0.6f;
+
     // Saw speeds are limited to 180 or 360 degrees per second. Compute both
     // frame steps once, then advance each visible saw with angle addition.
     float step_180 = C3D_AngleFromDegrees(180.f * delta);
@@ -1267,18 +1312,27 @@ void create_objects() {
                 int fade_val = obj_edge_fade(calc_x, SCREEN_WIDTH / SCALE);
                 bool fade_edge = (fade_val == 255 || fade_val == 0);
 
-                if (fade_edge) handle_special_fading(obj, calc_x, calc_y);
+                if (fade_edge) {
+                    if (current_fading_effect == FADE_NONE) {
+                        objects.transition_applied[obj] = FADE_NONE;
+                    } else {
+                        handle_special_fading(obj, calc_x, calc_y);
+                    }
+                }
                 int fade_x = 0;
                 int fade_y = 0;
 
                 float fade_scale = 1.f;
 
-                get_fade_vars_from_value(obj, fade_val, &fade_x, &fade_y, &fade_scale);
+                u8 fade_transition = objects.transition_applied[obj];
+                if (fade_transition != FADE_NONE) {
+                    get_fade_vars_from_value(obj, fade_val, &fade_x, &fade_y, &fade_scale);
+                }
 
                 // Handle saw rotation
                 float rotation_sin = objects.rotation_sin[obj];
                 float rotation_cos = objects.rotation_cos[obj];
-                float rotation_speed = get_rotation_speed(objects.id[obj]);
+                float rotation_speed = sprite_templates[objects.id[obj]].rotation_speed;
                 if (rotation_speed != 0.f) {
                     bool reverse = (objects.random[obj] & 1) != 0;
                     float step_sin = rotation_speed == 360.f ? step_360_sin : step_180_sin;
@@ -1306,7 +1360,9 @@ void create_objects() {
                 }
                 
                 // Handle special fade types
-                get_special_fading_vars(obj, fade_val, &calc_x);
+                if (fade_transition == FADE_DOWN_STATIONARY || fade_transition == FADE_UP_STATIONARY) {
+                    get_special_fading_vars(obj, fade_val, &calc_x);
+                }
 
                 int edge_opacity = get_obj_opacity_from_fade(obj, fade_val);
                 float fading_opacity = 1.f;
@@ -1330,7 +1386,9 @@ void create_objects() {
                     glow_opacity
                 );
 
-                spawn_object_particles(obj);
+                if (sprite_templates[objects.id[obj]].has_particles) {
+                    spawn_object_particles(obj);
+                }
             }
         }
     }

--- a/source/graphics.h
+++ b/source/graphics.h
@@ -37,11 +37,14 @@ typedef struct SpriteObject
     C2D_Image image;
     float x;
     float y;
+    float offset_x;
+    float offset_y;
     float half_width;
     float half_height;
     float rotation_sin;
     float rotation_cos;
     u32 color_meta;
+    u32 fade_meta;
     int obj;
     int layer;
     float opacity;
@@ -121,6 +124,8 @@ extern C2D_SpriteSheet particleSheet;
 extern SpriteTemplate sprite_templates[GAME_OBJECT_COUNT];
 
 extern const Color white;
+
+extern float object_pulse_scales[4];
 
 extern float object_creating_time;
 extern float object_sorting_time;

--- a/source/graphics.h
+++ b/source/graphics.h
@@ -41,7 +41,7 @@ typedef struct SpriteObject
     float half_height;
     float rotation_sin;
     float rotation_cos;
-    u32 tint_color;
+    u32 color_meta;
     int obj;
     int layer;
     float opacity;
@@ -90,6 +90,12 @@ typedef struct {
     C2D_Sprite glow_template;
     int child_count;
     ChildSpriteTemplate *child_templates;
+    float rotation_speed;
+    int glow_channel;
+    u8 pulse_mode;
+    u8 fade_opacity_mode;
+    bool fades;
+    bool has_particles;
 } SpriteTemplate;
 
 void cache_all_sprites();

--- a/source/graphics.h
+++ b/source/graphics.h
@@ -32,16 +32,25 @@ typedef struct
     float dx, dy; // velocity
 } Sprite;
 
-typedef struct
+typedef struct SpriteObject
 {
-    C2D_Sprite spr;
-    C2D_ImageTint tint;
+    C2D_Image image;
+    float x;
+    float y;
+    float half_width;
+    float half_height;
+    float rotation_sin;
+    float rotation_cos;
+    u32 tint_color;
     int obj;
     int layer;
-    int col_type;
     float opacity;
     int col_channel;
-    int zlayer;
+    int render_slot;
+    bool flip_x;
+    bool flip_y;
+    bool blending;
+    bool visible;
 } SpriteObject;
 
 typedef struct {
@@ -71,10 +80,16 @@ enum FadingEffects {
 };
 
 typedef struct {
+    C2D_Sprite sprite;
+    float rotation_sin;
+    float rotation_cos;
+} ChildSpriteTemplate;
+
+typedef struct {
     C2D_Sprite parent_template;
     C2D_Sprite glow_template;
     int child_count;
-    C2D_Sprite *child_templates;
+    ChildSpriteTemplate *child_templates;
 } SpriteTemplate;
 
 void cache_all_sprites();

--- a/source/level_loading.c
+++ b/source/level_loading.c
@@ -3,6 +3,7 @@
 #include "level_loading.h"
 #include <zlib.h>
 #include <ctype.h>
+#include <math.h>
 #include <string.h>
 #include <stdio.h>
 #include "color_channels.h"
@@ -884,7 +885,12 @@ void fill_object_data(int object, int key, GDValueType type, GDValue val) {
             if (type == GD_VAL_BOOL) objects.flippedV[object] = val.b;
             break;
         case 6:  // Rotation
-            if (type == GD_VAL_FLOAT) objects.rotation[object] = val.f;
+            if (type == GD_VAL_FLOAT) {
+                objects.rotation[object] = val.f;
+                float radians = C3D_AngleFromDegrees(val.f);
+                objects.rotation_sin[object] = sinf(radians);
+                objects.rotation_cos[object] = cosf(radians);
+            }
             break;
         case 7:  // Color R
             if (type == GD_VAL_INT) objects.trig_colorR[object] = val.i;
@@ -1066,6 +1072,8 @@ void free_arrays() {
     if (objects.x)                  { free(objects.x);                  objects.x = NULL; }
     if (objects.y)                  { free(objects.y);                  objects.y = NULL; }
     if (objects.rotation)           { free(objects.rotation);           objects.rotation = NULL; }
+    if (objects.rotation_sin)       { free(objects.rotation_sin);       objects.rotation_sin = NULL; }
+    if (objects.rotation_cos)       { free(objects.rotation_cos);       objects.rotation_cos = NULL; }
     if (objects.zlayer)             { free(objects.zlayer);             objects.zlayer = NULL; }
     if (objects.zorder)             { free(objects.zorder);             objects.zorder = NULL; }
     if (objects.trig_duration)      { free(objects.trig_duration);      objects.trig_duration = NULL; }
@@ -1109,6 +1117,12 @@ bool init_arrays(int count) {
 
     objects.rotation = malloc(sizeof(float) * count);
     if (!objects.rotation) return false;
+
+    objects.rotation_sin = malloc(sizeof(float) * count);
+    if (!objects.rotation_sin) return false;
+
+    objects.rotation_cos = malloc(sizeof(float) * count);
+    if (!objects.rotation_cos) return false;
 
     objects.zlayer = malloc(sizeof(int) * count);
     if (!objects.zlayer) return false;
@@ -1194,6 +1208,8 @@ bool init_arrays(int count) {
     memset(objects.x,                  0, sizeof(float) * count);
     memset(objects.y,                  0, sizeof(float) * count);
     memset(objects.rotation,           0, sizeof(float) * count);
+    memset(objects.rotation_sin,       0, sizeof(float) * count);
+    for (int i = 0; i < count; i++) objects.rotation_cos[i] = 1.f;
     memset(objects.zlayer,             0, sizeof(int) * count);
     memset(objects.zorder,             0, sizeof(int) * count);
     memset(objects.trig_duration,      0, sizeof(float) * count);

--- a/source/level_loading.c
+++ b/source/level_loading.c
@@ -1430,14 +1430,14 @@ int load_online_level(LevelEntry *level) {
     // Set pulserod pulse ball image
     current_pulserod_ball_image = game_objects[15].children[0].texture + (rand() % 3);
 
-    C2D_SpriteFromSheet(&sprite_templates[15].child_templates[0], spriteSheet, current_pulserod_ball_image);
-    C2D_SpriteSetCenter(&sprite_templates[15].child_templates[0], 0.5f, 0.5f);
+    C2D_SpriteFromSheet(&sprite_templates[15].child_templates[0].sprite, spriteSheet, current_pulserod_ball_image);
+    C2D_SpriteSetCenter(&sprite_templates[15].child_templates[0].sprite, 0.5f, 0.5f);
     
-    C2D_SpriteFromSheet(&sprite_templates[16].child_templates[0], spriteSheet, current_pulserod_ball_image);
-    C2D_SpriteSetCenter(&sprite_templates[16].child_templates[0], 0.5f, 0.5f);
+    C2D_SpriteFromSheet(&sprite_templates[16].child_templates[0].sprite, spriteSheet, current_pulserod_ball_image);
+    C2D_SpriteSetCenter(&sprite_templates[16].child_templates[0].sprite, 0.5f, 0.5f);
 
-    C2D_SpriteFromSheet(&sprite_templates[17].child_templates[0], spriteSheet, current_pulserod_ball_image);
-    C2D_SpriteSetCenter(&sprite_templates[17].child_templates[0], 0.5f, 0.5f);
+    C2D_SpriteFromSheet(&sprite_templates[17].child_templates[0].sprite, spriteSheet, current_pulserod_ball_image);
+    C2D_SpriteSetCenter(&sprite_templates[17].child_templates[0].sprite, 0.5f, 0.5f);
 
     return 0;
 }
@@ -1515,14 +1515,14 @@ int load_level(char *path) {
     // Set pulserod pulse ball image
     current_pulserod_ball_image = game_objects[15].children[0].texture + (rand() % 3);
 
-    C2D_SpriteFromSheet(&sprite_templates[15].child_templates[0], spriteSheet, current_pulserod_ball_image);
-    C2D_SpriteSetCenter(&sprite_templates[15].child_templates[0], 0.5f, 0.5f);
+    C2D_SpriteFromSheet(&sprite_templates[15].child_templates[0].sprite, spriteSheet, current_pulserod_ball_image);
+    C2D_SpriteSetCenter(&sprite_templates[15].child_templates[0].sprite, 0.5f, 0.5f);
     
-    C2D_SpriteFromSheet(&sprite_templates[16].child_templates[0], spriteSheet, current_pulserod_ball_image);
-    C2D_SpriteSetCenter(&sprite_templates[16].child_templates[0], 0.5f, 0.5f);
+    C2D_SpriteFromSheet(&sprite_templates[16].child_templates[0].sprite, spriteSheet, current_pulserod_ball_image);
+    C2D_SpriteSetCenter(&sprite_templates[16].child_templates[0].sprite, 0.5f, 0.5f);
 
-    C2D_SpriteFromSheet(&sprite_templates[17].child_templates[0], spriteSheet, current_pulserod_ball_image);
-    C2D_SpriteSetCenter(&sprite_templates[17].child_templates[0], 0.5f, 0.5f);
+    C2D_SpriteFromSheet(&sprite_templates[17].child_templates[0].sprite, spriteSheet, current_pulserod_ball_image);
+    C2D_SpriteSetCenter(&sprite_templates[17].child_templates[0].sprite, 0.5f, 0.5f);
 
     return 0;
 }

--- a/source/level_loading.h
+++ b/source/level_loading.h
@@ -30,6 +30,7 @@ typedef struct {
     int *id;
     float *x, *y;
     float *rotation;
+    float *rotation_sin, *rotation_cos;
     int *zlayer, *zorder;
     float *trig_duration;
     float *opacity;

--- a/source/main.c
+++ b/source/main.c
@@ -13,6 +13,7 @@
 #include "level_loading.h"
 #include "main.h"
 #include "graphics.h"
+#include "object_renderer.h"
 #include "color_channels.h"
 #include "mp3_player.h"
 #include "level/main_levels.h"
@@ -1333,6 +1334,7 @@ int main(int argc, char* argv[]) {
     C3D_Init(C3D_DEFAULT_CMDBUF_SIZE * 4);
     C2D_Init(MAX_SPRITES);
     C2D_Prepare();
+    if (!object_renderer_init()) svcBreak(USERBREAK_PANIC);
     osSetSpeedupEnable(1);
     soc_init();
     check_system_model();
@@ -1507,6 +1509,7 @@ int main(int argc, char* argv[]) {
     cfg_fini();
 
     // Deinit libs
+    object_renderer_fini();
     C2D_Fini();
     C3D_Fini();
     gfxExit();

--- a/source/object.v.pica
+++ b/source/object.v.pica
@@ -1,9 +1,11 @@
 ; Batched Geometry Dash object vertex shader
 
 .fvec mdlvMtx[4], projMtx[4], channelColors[21], p1Color
+.fvec fadeModes[17], pulseScales[4], cameraParams, mirrorParams
 
 .constf common_const(0.0, 1.0, 0.5, 0.003921568393707275390625)
 .constf invisible_const(1.9, -1.5, 0.8, 0.0)
+.constf transform_const(255.0, -2.0, 0.015625, 0.0)
 .alias clrdiv common_const.wwww
 
 .out outPosition position
@@ -12,19 +14,55 @@
 
 .in inLocal v0
 .in inPosition v1
-.in inRotation v2
-.in inTexCoord v3
-.in inMeta v4
+.in inOffset v2
+.in inRotation v3
+.in inTexCoord v4
+.in inMeta v5
+.in inFadeMeta v6
 
 .entry object_main
 .proc object_main
-    ; Rotate the local corner with the per-object sin/cos pair, then translate it.
+    ; Resolve the fade and pulse modes from compact per-sprite indices.
+    mova a0.x, inFadeMeta.y
+    mov r6, fadeModes[a0.x]
+    mul r7.x, clrdiv, inFadeMeta.x
+    add r7.y, transform_const.x, -inFadeMeta.x
+    mul r7.y, common_const.z, r7.y
+    flr r7.y, r7.y
+    mul r7.z, r7.x, r6.w
+    add r7.z, r6.z, r7.z
+
+    mova a0.x, inFadeMeta.z
+    mov r8, pulseScales[a0.x]
+    mov r7.w, r8.x
+
+    ; Convert the shared world root to screen space and apply fade translation.
+    add r8.x, -cameraParams.x, inPosition.x
+    add r8.y, -cameraParams.y, inPosition.y
+    add r8.y, cameraParams.z, -r8.y
+    mad r8.x, r7.y, r6.x, r8.x
+    mad r8.y, r7.y, r6.y, r8.y
+
+    ; Mirror the root continuously. Discrete sprite orientation remains packed
+    ; by the CPU so relative child rotations preserve the original behavior.
+    mul r9.x, transform_const.y, r8.x
+    add r9.x, mirrorParams.z, r9.x
+    mad r8.x, r9.x, mirrorParams.x, r8.x
+
+    mul r9.xy, transform_const.z, inOffset.xy
+    mul r9.xy, r7.zz, r9.xy
+
+    ; Rotate the local corner, then apply the shared fade and pulse scales.
     mov r2.xy, inLocal.xy
     mul r0.xy, r2.xy, inRotation.yy
     mul r1.xy, r2.yx, inRotation.xx
     add r0.x, r0.x, -r1.x
     add r0.y, r0.y, r1.y
-    add r0.xy, r0.xy, inPosition.xy
+    mul r0.xy, r7.zz, r0.xy
+    mul r0.xy, r7.ww, r0.xy
+    add r0.xy, r0.xy, r9.xy
+    add r0.x, r0.x, r8.x
+    add r0.y, r0.y, r8.y
     mov r0.zw, common_const.xy
 
     ; Preserve Citro2D's current view and projection transforms.

--- a/source/object.v.pica
+++ b/source/object.v.pica
@@ -1,0 +1,43 @@
+; Batched Geometry Dash object vertex shader
+
+.fvec mdlvMtx[4], projMtx[4]
+
+.constf common_const(0.0, 1.0, 0.5, 0.003921568393707275390625)
+.alias clrdiv common_const.wwww
+
+.out outPosition position
+.out outTexCoord texcoord0
+.out outColor color
+
+.in inLocal v0
+.in inPosition v1
+.in inRotation v2
+.in inTexCoord v3
+.in inColor v4
+
+.entry object_main
+.proc object_main
+    ; Rotate the local corner with the per-object sin/cos pair, then translate it.
+    mov r2.xy, inLocal.xy
+    mul r0.xy, r2.xy, inRotation.yy
+    mul r1.xy, r2.yx, inRotation.xx
+    add r0.x, r0.x, -r1.x
+    add r0.y, r0.y, r1.y
+    add r0.xy, r0.xy, inPosition.xy
+    mov r0.zw, common_const.xy
+
+    ; Preserve Citro2D's current view and projection transforms.
+    dp4 r1.x, mdlvMtx[0], r0
+    dp4 r1.y, mdlvMtx[1], r0
+    dp4 r1.z, mdlvMtx[2], r0
+    dp4 r1.w, mdlvMtx[3], r0
+
+    dp4 outPosition.x, projMtx[0], r1
+    dp4 outPosition.y, projMtx[1], r1
+    dp4 outPosition.z, projMtx[2], r1
+    dp4 outPosition.w, projMtx[3], r1
+
+    mov outTexCoord, inTexCoord
+    mul outColor, clrdiv, inColor
+    end
+.end

--- a/source/object.v.pica
+++ b/source/object.v.pica
@@ -1,8 +1,9 @@
 ; Batched Geometry Dash object vertex shader
 
-.fvec mdlvMtx[4], projMtx[4]
+.fvec mdlvMtx[4], projMtx[4], channelColors[21], p1Color
 
 .constf common_const(0.0, 1.0, 0.5, 0.003921568393707275390625)
+.constf invisible_const(1.9, -1.5, 0.8, 0.0)
 .alias clrdiv common_const.wwww
 
 .out outPosition position
@@ -13,7 +14,7 @@
 .in inPosition v1
 .in inRotation v2
 .in inTexCoord v3
-.in inColor v4
+.in inMeta v4
 
 .entry object_main
 .proc object_main
@@ -38,6 +39,24 @@
     dp4 outPosition.w, projMtx[3], r1
 
     mov outTexCoord, inTexCoord
-    mul outColor, clrdiv, inColor
+
+    ; Select one of the small set of live color channels on the GPU. inMeta is
+    ; packed as channel index, layer alpha, parent alpha, invisible-glow mix.
+    mova a0.x, inMeta.x
+    mov r5, channelColors[a0.x]
+    mul r5.w, clrdiv, inMeta.y
+
+    ; Invisible glow blends the player and LBG colors only above its threshold.
+    ; The CPU sets the flag so ordinary layers do not take this path.
+    cmp common_const.x, ne, ne, inMeta.w
+    ifc cmp.x
+        mul r3.x, clrdiv, inMeta.z
+        mul r3.y, invisible_const.y, r3.x
+        add r3.y, invisible_const.x, r3.y
+        add r3.z, common_const.y, -r3.y
+        mul r4.xyz, r3.y, r5
+        mad r5.xyz, r3.z, p1Color, r4
+    .end
+    mov outColor, r5
     end
 .end

--- a/source/object_renderer.c
+++ b/source/object_renderer.c
@@ -24,6 +24,8 @@ static ObjectVertex *object_vertices;
 static u16 *object_indices;
 static int object_mdlv_uniform;
 static int object_proj_uniform;
+static int object_colors_uniform;
+static int object_p1_uniform;
 static int built_sprite_count;
 static int current_blending = -1;
 static C3D_Tex *current_texture;
@@ -43,7 +45,7 @@ static void set_vertex(
     vertex->rotation[1] = sprite->rotation_cos;
     vertex->texcoord[0] = uv[0];
     vertex->texcoord[1] = uv[1];
-    vertex->color = sprite->tint_color;
+    vertex->color = sprite->color_meta;
 }
 
 bool object_renderer_init(void) {
@@ -75,7 +77,10 @@ bool object_renderer_init(void) {
     shaderProgramSetVsh(&object_shader, &object_shader_dvlb->DVLE[0]);
     object_mdlv_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "mdlvMtx");
     object_proj_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "projMtx");
-    if (object_mdlv_uniform < 0 || object_proj_uniform < 0) {
+    object_colors_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "channelColors");
+    object_p1_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "p1Color");
+    if (object_mdlv_uniform < 0 || object_proj_uniform < 0
+        || object_colors_uniform < 0 || object_p1_uniform < 0) {
         object_renderer_fini();
         return false;
     }
@@ -155,6 +160,18 @@ void object_renderer_begin(void) {
     C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, object_mdlv_uniform, &c2d->mdlvMtx);
     C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, object_proj_uniform, &c2d->projMtx);
 
+    const float color_scale = 1.f / 255.f;
+    for (int i = 0; i < COL_CHANNEL_NUM; i++) {
+        Color color = channels[i].color;
+        C3D_FVUnifSet(GPU_VERTEX_SHADER, object_colors_uniform + i,
+            color.r * color_scale, color.g * color_scale, color.b * color_scale, 1.f);
+    }
+    C3D_FVUnifSet(GPU_VERTEX_SHADER, object_colors_uniform + COL_CHANNEL_NUM, 1.f, 1.f, 1.f, 1.f);
+
+    Color p1 = get_white_if_black(p1_color);
+    C3D_FVUnifSet(GPU_VERTEX_SHADER, object_p1_uniform,
+        p1.r * color_scale, p1.g * color_scale, p1.b * color_scale, 1.f);
+
     C3D_TexEnv *env = C3D_GetTexEnv(0);
     C3D_TexEnvInit(env);
     C3D_TexEnvSrc(env, C3D_Both, GPU_TEXTURE0, GPU_PRIMARY_COLOR, 0);
@@ -163,7 +180,10 @@ void object_renderer_begin(void) {
     C3D_TexEnvInit(C3D_GetTexEnv(2));
     C3D_TexEnvInit(C3D_GetTexEnv(3));
 
-    C3D_DepthTest(true, GPU_GEQUAL, GPU_WRITE_ALL);
+    // The sorted object list is painter-ordered and is interrupted to draw the
+    // player. Disable depth rejection so later layers always win across those
+    // raw/Citro2D transitions.
+    C3D_DepthTest(false, GPU_ALWAYS, GPU_WRITE_COLOR);
     C3D_CullFace(GPU_CULL_NONE);
     current_blending = -1;
     current_texture = NULL;

--- a/source/object_renderer.c
+++ b/source/object_renderer.c
@@ -1,0 +1,217 @@
+#include "object_renderer.h"
+
+#include <stdlib.h>
+
+#include "graphics.h"
+#include "object_shbin.h"
+#include "utils/c2d_internal.h"
+
+typedef struct {
+    float local[2];
+    float position[2];
+    float rotation[2];
+    float texcoord[2];
+    u32 color;
+} ObjectVertex;
+
+_Static_assert(sizeof(ObjectVertex) == 36, "ObjectVertex layout must match object.v.pica");
+
+static DVLB_s *object_shader_dvlb;
+static shaderProgram_s object_shader;
+static C3D_AttrInfo object_attr_info;
+static C3D_BufInfo object_buf_info;
+static ObjectVertex *object_vertices;
+static u16 *object_indices;
+static int object_mdlv_uniform;
+static int object_proj_uniform;
+static int built_sprite_count;
+static int current_blending = -1;
+static C3D_Tex *current_texture;
+
+static void set_vertex(
+    ObjectVertex *vertex,
+    const SpriteObject *sprite,
+    float local_x,
+    float local_y,
+    const float uv[2]
+) {
+    vertex->local[0] = local_x;
+    vertex->local[1] = local_y;
+    vertex->position[0] = sprite->x;
+    vertex->position[1] = sprite->y;
+    vertex->rotation[0] = sprite->rotation_sin;
+    vertex->rotation[1] = sprite->rotation_cos;
+    vertex->texcoord[0] = uv[0];
+    vertex->texcoord[1] = uv[1];
+    vertex->color = sprite->tint_color;
+}
+
+bool object_renderer_init(void) {
+    object_vertices = linearAlloc(sizeof(ObjectVertex) * MAX_SPRITES * 4);
+    object_indices = linearAlloc(sizeof(u16) * MAX_SPRITES * 6);
+    if (!object_vertices || !object_indices) {
+        object_renderer_fini();
+        return false;
+    }
+
+    for (int i = 0; i < MAX_SPRITES; i++) {
+        u16 base = i * 4;
+        u16 *indices = &object_indices[i * 6];
+        indices[0] = base;
+        indices[1] = base + 2;
+        indices[2] = base + 1;
+        indices[3] = base + 1;
+        indices[4] = base + 2;
+        indices[5] = base + 3;
+    }
+
+    object_shader_dvlb = DVLB_ParseFile((u32 *)object_shbin, object_shbin_size);
+    if (!object_shader_dvlb) {
+        object_renderer_fini();
+        return false;
+    }
+
+    shaderProgramInit(&object_shader);
+    shaderProgramSetVsh(&object_shader, &object_shader_dvlb->DVLE[0]);
+    object_mdlv_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "mdlvMtx");
+    object_proj_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "projMtx");
+    if (object_mdlv_uniform < 0 || object_proj_uniform < 0) {
+        object_renderer_fini();
+        return false;
+    }
+
+    AttrInfo_Init(&object_attr_info);
+    AttrInfo_AddLoader(&object_attr_info, 0, GPU_FLOAT, 2);
+    AttrInfo_AddLoader(&object_attr_info, 1, GPU_FLOAT, 2);
+    AttrInfo_AddLoader(&object_attr_info, 2, GPU_FLOAT, 2);
+    AttrInfo_AddLoader(&object_attr_info, 3, GPU_FLOAT, 2);
+    AttrInfo_AddLoader(&object_attr_info, 4, GPU_UNSIGNED_BYTE, 4);
+
+    BufInfo_Init(&object_buf_info);
+    BufInfo_Add(&object_buf_info, object_vertices, sizeof(ObjectVertex), 5, 0x43210);
+    return true;
+}
+
+void object_renderer_fini(void) {
+    if (object_shader_dvlb) {
+        shaderProgramFree(&object_shader);
+        DVLB_Free(object_shader_dvlb);
+        object_shader_dvlb = NULL;
+    }
+    if (object_indices) {
+        linearFree(object_indices);
+        object_indices = NULL;
+    }
+    if (object_vertices) {
+        linearFree(object_vertices);
+        object_vertices = NULL;
+    }
+}
+
+void object_renderer_build(SpriteObject *const *objects, int count) {
+    built_sprite_count = 0;
+
+    for (int i = 0; i < count; i++) {
+        SpriteObject *sprite = objects[i];
+        sprite->render_slot = -1;
+        if (sprite->obj == -1 || !sprite->visible || built_sprite_count >= MAX_SPRITES) continue;
+
+        float uv_top_left[2];
+        float uv_top_right[2];
+        float uv_bottom_left[2];
+        float uv_bottom_right[2];
+        Tex3DS_SubTextureTopLeft(sprite->image.subtex, uv_top_left, uv_top_left + 1);
+        Tex3DS_SubTextureTopRight(sprite->image.subtex, uv_top_right, uv_top_right + 1);
+        Tex3DS_SubTextureBottomLeft(sprite->image.subtex, uv_bottom_left, uv_bottom_left + 1);
+        Tex3DS_SubTextureBottomRight(sprite->image.subtex, uv_bottom_right, uv_bottom_right + 1);
+
+        if (sprite->flip_x) {
+            C2Di_SwapUV(uv_top_left, uv_top_right);
+            C2Di_SwapUV(uv_bottom_left, uv_bottom_right);
+        }
+        if (sprite->flip_y) {
+            C2Di_SwapUV(uv_top_left, uv_bottom_left);
+            C2Di_SwapUV(uv_top_right, uv_bottom_right);
+        }
+
+        ObjectVertex *vertices = &object_vertices[built_sprite_count * 4];
+        set_vertex(&vertices[0], sprite, -sprite->half_width, -sprite->half_height, uv_top_left);
+        set_vertex(&vertices[1], sprite,  sprite->half_width, -sprite->half_height, uv_top_right);
+        set_vertex(&vertices[2], sprite, -sprite->half_width,  sprite->half_height, uv_bottom_left);
+        set_vertex(&vertices[3], sprite,  sprite->half_width,  sprite->half_height, uv_bottom_right);
+
+        sprite->render_slot = built_sprite_count++;
+    }
+}
+
+void object_renderer_begin(void) {
+    C2D_Flush();
+
+    C3D_BindProgram(&object_shader);
+    C3D_SetAttrInfo(&object_attr_info);
+    C3D_SetBufInfo(&object_buf_info);
+
+    C2Di_Context *c2d = C2Di_GetContext();
+    C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, object_mdlv_uniform, &c2d->mdlvMtx);
+    C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, object_proj_uniform, &c2d->projMtx);
+
+    C3D_TexEnv *env = C3D_GetTexEnv(0);
+    C3D_TexEnvInit(env);
+    C3D_TexEnvSrc(env, C3D_Both, GPU_TEXTURE0, GPU_PRIMARY_COLOR, 0);
+    C3D_TexEnvFunc(env, C3D_Both, GPU_MODULATE);
+    C3D_TexEnvInit(C3D_GetTexEnv(1));
+    C3D_TexEnvInit(C3D_GetTexEnv(2));
+    C3D_TexEnvInit(C3D_GetTexEnv(3));
+
+    C3D_DepthTest(true, GPU_GEQUAL, GPU_WRITE_ALL);
+    C3D_CullFace(GPU_CULL_NONE);
+    current_blending = -1;
+    current_texture = NULL;
+}
+
+static void set_blending(bool blending) {
+    if (current_blending == blending) return;
+
+    C3D_TexEnv *env = C3D_GetTexEnv(4);
+    C3D_TexEnvInit(env);
+    if (blending) {
+        C3D_AlphaBlend(
+            GPU_BLEND_ADD, GPU_BLEND_ADD,
+            GPU_SRC_ALPHA, GPU_ONE,
+            GPU_ONE, GPU_ZERO);
+        C3D_TexEnvSrc(env, C3D_Alpha, GPU_PREVIOUS, GPU_PREVIOUS, 0);
+        C3D_TexEnvFunc(env, C3D_Alpha, GPU_MODULATE);
+    } else {
+        C3D_AlphaBlend(
+            GPU_BLEND_ADD, GPU_BLEND_ADD,
+            GPU_SRC_ALPHA, GPU_ONE_MINUS_SRC_ALPHA,
+            GPU_ONE, GPU_ZERO);
+    }
+    current_blending = blending;
+}
+
+void object_renderer_draw_batch(int first_slot, int sprite_count, C3D_Tex *texture, bool blending) {
+    if (sprite_count <= 0 || first_slot < 0 || first_slot + sprite_count > built_sprite_count) return;
+
+    set_blending(blending);
+    if (texture != current_texture) {
+        C3D_TexBind(0, texture);
+        current_texture = texture;
+    }
+
+    C3D_DrawElements(
+        GPU_TRIANGLES,
+        sprite_count * 6,
+        C3D_UNSIGNED_SHORT,
+        &object_indices[first_slot * 6]);
+}
+
+void object_renderer_end(void) {
+    // Restore the complete Citro2D pipeline before player/particle/UI drawing.
+    C2D_Prepare();
+    C3D_AlphaBlend(
+        GPU_BLEND_ADD, GPU_BLEND_ADD,
+        GPU_SRC_ALPHA, GPU_ONE_MINUS_SRC_ALPHA,
+        GPU_ONE, GPU_ZERO);
+    C3D_TexEnvInit(C3D_GetTexEnv(4));
+}

--- a/source/object_renderer.c
+++ b/source/object_renderer.c
@@ -1,20 +1,51 @@
 #include "object_renderer.h"
 
+#include <math.h>
+#include <stddef.h>
 #include <stdlib.h>
 
 #include "graphics.h"
 #include "object_shbin.h"
+#include "state.h"
 #include "utils/c2d_internal.h"
 
 typedef struct {
     float local[2];
     float position[2];
+    s16 offset[2];
     float rotation[2];
     float texcoord[2];
     u32 color;
+    u32 fade;
 } ObjectVertex;
 
-_Static_assert(sizeof(ObjectVertex) == 36, "ObjectVertex layout must match object.v.pica");
+_Static_assert(sizeof(ObjectVertex) == 44, "ObjectVertex layout must match object.v.pica");
+_Static_assert(offsetof(ObjectVertex, position) == 8, "ObjectVertex position offset mismatch");
+_Static_assert(offsetof(ObjectVertex, offset) == 16, "ObjectVertex center offset mismatch");
+_Static_assert(offsetof(ObjectVertex, rotation) == 20, "ObjectVertex rotation offset mismatch");
+_Static_assert(offsetof(ObjectVertex, texcoord) == 28, "ObjectVertex texcoord offset mismatch");
+_Static_assert(offsetof(ObjectVertex, color) == 36, "ObjectVertex color offset mismatch");
+_Static_assert(offsetof(ObjectVertex, fade) == 40, "ObjectVertex fade offset mismatch");
+
+static const float fade_modes[FADE_COUNT][4] = {
+    [FADE_NONE]                = {  0.f,       0.f,       1.f,  0.f  },
+    [FADE_UP]                  = {  0.f,       1.f,       1.f,  0.f  },
+    [FADE_DOWN]                = {  0.f,      -1.f,       1.f,  0.f  },
+    [FADE_RIGHT]               = {  1.f,       0.f,       1.f,  0.f  },
+    [FADE_LEFT]                = { -1.f,       0.f,       1.f,  0.f  },
+    [FADE_SCALE_IN]            = {  0.f,       0.f,       0.f,  1.f  },
+    [FADE_SCALE_OUT]           = {  0.f,       0.f,       1.5f, -0.5f },
+    [FADE_INWARDS]             = {  0.f,       0.f,       1.f,  0.f  },
+    [FADE_OUTWARDS]            = {  0.f,       0.f,       1.f,  0.f  },
+    [FADE_CIRCLE_LEFT]         = {  0.f,       0.f,       1.f,  0.f  },
+    [FADE_CIRCLE_RIGHT]        = {  0.f,       0.f,       1.f,  0.f  },
+    [FADE_UP_SLOW_LEFT]        = { -1.f,       1.f / 3.f, 1.f,  0.f  },
+    [FADE_DOWN_SLOW_LEFT]      = { -1.f,      -1.f / 3.f, 1.f,  0.f  },
+    [FADE_UP_SLOW_RIGHT]       = {  1.f,       1.f / 3.f, 1.f,  0.f  },
+    [FADE_DOWN_SLOW_RIGHT]     = {  1.f,      -1.f / 3.f, 1.f,  0.f  },
+    [FADE_UP_STATIONARY]       = {  0.f,       1.f / 3.f, 1.f,  0.f  },
+    [FADE_DOWN_STATIONARY]     = {  0.f,      -1.f / 3.f, 1.f,  0.f  },
+};
 
 static DVLB_s *object_shader_dvlb;
 static shaderProgram_s object_shader;
@@ -26,6 +57,10 @@ static int object_mdlv_uniform;
 static int object_proj_uniform;
 static int object_colors_uniform;
 static int object_p1_uniform;
+static int object_fade_modes_uniform;
+static int object_pulse_scales_uniform;
+static int object_camera_uniform;
+static int object_mirror_uniform;
 static int built_sprite_count;
 static int current_blending = -1;
 static C3D_Tex *current_texture;
@@ -41,11 +76,14 @@ static void set_vertex(
     vertex->local[1] = local_y;
     vertex->position[0] = sprite->x;
     vertex->position[1] = sprite->y;
+    vertex->offset[0] = (s16)lrintf(sprite->offset_x * 64.f);
+    vertex->offset[1] = (s16)lrintf(sprite->offset_y * 64.f);
     vertex->rotation[0] = sprite->rotation_sin;
     vertex->rotation[1] = sprite->rotation_cos;
     vertex->texcoord[0] = uv[0];
     vertex->texcoord[1] = uv[1];
     vertex->color = sprite->color_meta;
+    vertex->fade = sprite->fade_meta;
 }
 
 bool object_renderer_init(void) {
@@ -79,8 +117,14 @@ bool object_renderer_init(void) {
     object_proj_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "projMtx");
     object_colors_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "channelColors");
     object_p1_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "p1Color");
+    object_fade_modes_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "fadeModes");
+    object_pulse_scales_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "pulseScales");
+    object_camera_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "cameraParams");
+    object_mirror_uniform = shaderInstanceGetUniformLocation(object_shader.vertexShader, "mirrorParams");
     if (object_mdlv_uniform < 0 || object_proj_uniform < 0
-        || object_colors_uniform < 0 || object_p1_uniform < 0) {
+        || object_colors_uniform < 0 || object_p1_uniform < 0
+        || object_fade_modes_uniform < 0 || object_pulse_scales_uniform < 0
+        || object_camera_uniform < 0 || object_mirror_uniform < 0) {
         object_renderer_fini();
         return false;
     }
@@ -88,12 +132,14 @@ bool object_renderer_init(void) {
     AttrInfo_Init(&object_attr_info);
     AttrInfo_AddLoader(&object_attr_info, 0, GPU_FLOAT, 2);
     AttrInfo_AddLoader(&object_attr_info, 1, GPU_FLOAT, 2);
-    AttrInfo_AddLoader(&object_attr_info, 2, GPU_FLOAT, 2);
+    AttrInfo_AddLoader(&object_attr_info, 2, GPU_SHORT, 2);
     AttrInfo_AddLoader(&object_attr_info, 3, GPU_FLOAT, 2);
-    AttrInfo_AddLoader(&object_attr_info, 4, GPU_UNSIGNED_BYTE, 4);
+    AttrInfo_AddLoader(&object_attr_info, 4, GPU_FLOAT, 2);
+    AttrInfo_AddLoader(&object_attr_info, 5, GPU_UNSIGNED_BYTE, 4);
+    AttrInfo_AddLoader(&object_attr_info, 6, GPU_UNSIGNED_BYTE, 4);
 
     BufInfo_Init(&object_buf_info);
-    BufInfo_Add(&object_buf_info, object_vertices, sizeof(ObjectVertex), 5, 0x43210);
+    BufInfo_Add(&object_buf_info, object_vertices, sizeof(ObjectVertex), 7, 0x6543210);
     return true;
 }
 
@@ -171,6 +217,19 @@ void object_renderer_begin(void) {
     Color p1 = get_white_if_black(p1_color);
     C3D_FVUnifSet(GPU_VERTEX_SHADER, object_p1_uniform,
         p1.r * color_scale, p1.g * color_scale, p1.b * color_scale, 1.f);
+
+    for (int i = 0; i < FADE_COUNT; i++) {
+        C3D_FVUnifSet(GPU_VERTEX_SHADER, object_fade_modes_uniform + i,
+            fade_modes[i][0], fade_modes[i][1], fade_modes[i][2], fade_modes[i][3]);
+    }
+    for (int i = 0; i < 4; i++) {
+        C3D_FVUnifSet(GPU_VERTEX_SHADER, object_pulse_scales_uniform + i,
+            object_pulse_scales[i], 0.f, 0.f, 0.f);
+    }
+    C3D_FVUnifSet(GPU_VERTEX_SHADER, object_camera_uniform,
+        state.camera_x, state.camera_y, SCREEN_HEIGHT, SCREEN_WIDTH / SCALE);
+    C3D_FVUnifSet(GPU_VERTEX_SHADER, object_mirror_uniform,
+        state.mirror_factor, state.mirror_mult, SCREEN_WIDTH / SCALE, 0.f);
 
     C3D_TexEnv *env = C3D_GetTexEnv(0);
     C3D_TexEnvInit(env);

--- a/source/object_renderer.h
+++ b/source/object_renderer.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <citro3d.h>
+
+typedef struct SpriteObject SpriteObject;
+
+bool object_renderer_init(void);
+void object_renderer_fini(void);
+
+void object_renderer_build(SpriteObject *const *objects, int count);
+void object_renderer_begin(void);
+void object_renderer_draw_batch(int first_slot, int sprite_count, C3D_Tex *texture, bool blending);
+void object_renderer_end(void);

--- a/source/particles/object_particles.c
+++ b/source/particles/object_particles.c
@@ -4,12 +4,22 @@
 #include "main.h"
 #include "player/collision.h"
 #include "math_helpers.h"
+#include <stdlib.h>
+#include <string.h>
 
 ObjectParticles object_particle[MAX_OBJECT_PS];
 
 ParticleSystem brick_destroy_particles;
+static s8 *object_particle_slots;
 
 void init_op_system() {
+    free(object_particle_slots);
+    object_particle_slots = NULL;
+    if (objects.count > 0) {
+        object_particle_slots = malloc(sizeof(*object_particle_slots) * objects.count);
+        if (object_particle_slots) memset(object_particle_slots, -1, sizeof(*object_particle_slots) * objects.count);
+    }
+
     for (size_t i = 0; i < MAX_OBJECT_PS; i++) {
         object_particle[i].id = -1;
         object_particle[i].occupied = false;
@@ -17,6 +27,16 @@ void init_op_system() {
 }
 
 bool is_ps_already_loaded(int id) {
+    if (object_particle_slots && id >= 0 && id < objects.count) {
+        int slot = object_particle_slots[id];
+        if (slot >= 0 && slot < MAX_OBJECT_PS
+            && object_particle[slot].occupied && object_particle[slot].id == id) {
+            return true;
+        }
+        object_particle_slots[id] = -1;
+        return false;
+    }
+
     for (size_t i = 0; i < MAX_OBJECT_PS; i++) {
         if (object_particle[i].occupied && object_particle[i].id == id) {
             return true;
@@ -59,6 +79,10 @@ static float get_object_particle_depth(int id) {
     return 0.f;
 }
 
+bool object_uses_particles(int id) {
+    return get_object_particle_depth(id) > 0.f;
+}
+
 int load_object_particles(int id, const ParticleDefinition *cfg, bool stationary) {
     for (size_t i = 0; i < MAX_OBJECT_PS; i++) {
         if (!object_particle[i].occupied) {
@@ -74,6 +98,7 @@ int load_object_particles(int id, const ParticleDefinition *cfg, bool stationary
             object_particle[i].ps.depthInwards = (cfg == &portal_effect_01 || cfg == &ring_effect);
 
             object_particle[i].ps.emitting = true;
+            if (object_particle_slots && id >= 0 && id < objects.count) object_particle_slots[id] = i;
             return i;
         }
     }
@@ -84,8 +109,11 @@ void free_object_particles() {
     for (size_t i = 0; i < MAX_OBJECT_PS; i++) {
         if (object_particle[i].occupied) {
             freeParticleData(&object_particle[i].ps.data);
+            object_particle[i].occupied = false;
         }
     }
+    free(object_particle_slots);
+    object_particle_slots = NULL;
 }
 
 static void remove_offscreen_object_particles() {
@@ -100,6 +128,9 @@ static void remove_offscreen_object_particles() {
             }
 
             if (x < -60 || x >= (SCREEN_WIDTH / SCALE) + 60 || y < -60 || y >= (SCREEN_HEIGHT / SCALE) + 60) {
+                if (object_particle_slots && object_particle[i].id >= 0 && object_particle[i].id < objects.count) {
+                    object_particle_slots[object_particle[i].id] = -1;
+                }
                 object_particle[i].occupied = false;
                 freeParticleData(&object_particle[i].ps.data);
             }

--- a/source/particles/object_particles.h
+++ b/source/particles/object_particles.h
@@ -14,6 +14,7 @@ extern ObjectParticles object_particle[MAX_OBJECT_PS];
 extern ParticleSystem brick_destroy_particles;
 
 void init_op_system();
+bool object_uses_particles(int id);
 bool is_ps_already_loaded(int id);
 int load_object_particles(int id, const ParticleDefinition *cfg, bool stationary);
 void draw_object_particles();


### PR DESCRIPTION
## Summary

- add a raw Citro3D renderer and PICA200 vertex shader for level objects
- move quad rotation/translation and live color-channel selection onto the GPU
- move camera subtraction, mirror-root placement, fade translation/scaling, and predictable pulse scaling into the vertex shader
- pack the remaining per-sprite transform inputs into 8 additional vertex bytes
- move invisible-glow player/LBG interpolation into the vertex shader
- batch consecutive objects by texture and blend state
- build object geometry once per frame and reuse it for the stereoscopic right eye
- retain Citro2D for the player, particles, background, UI, and discrete mirror orientation
- cache per-object rotation, glow, pulse, fade, and particle metadata
- compute pulse ranges once per frame and use fast paths for inactive fades
- advance the two supported saw speeds with shared frame sin/cos steps instead of per-object trigonometry
- replace each particle object's 48-slot linear search with an O(1) slot map
- fix the glow-sheet/blending collision in the packed layer sort key
- sandwich speed portal glow/arrow layers between normal portal back/front halves
- prevent the raw object pass from writing depth across the Citro2D player split

## Testing

- full `make -j` using the official `devkitpro/devkitarm` environment
- PICA shader assembled successfully
- linked and produced `GeometryDash3DS.3dsx`
- SHA-256: `ad30ab072c4421f6a73e8e8bbb111edf6b6a8318cb2c72a8ee3b262553cf3083`
- `git diff --check`

## Hardware validation requested

Azahar's reported GPU utilization should not be treated as real-hardware GPU evidence. This revision intentionally avoids the geometry-shader path because the game still interleaves raw Citro3D objects with Citro2D rendering.

Please compare FPS plus the in-game CPU, SprDraw/Creating, Drawing, command-buffer, and GPU counters on an actual Old and New 3DS at the same level position, with stereoscopic 3D both off and on. The vertex format is 8 bytes larger, so the result should be judged from hardware timings rather than assumed to be faster.

Please also check mirror transitions, all fade modes, pulsing rods/saws, and the speed-portal back/glow/arrow/front order.